### PR TITLE
Test chown usage in regards to security hints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,10 @@ ENV APP_VERSION=$COMMIT_SHA
 
 WORKDIR /home/node/kompla-app
 # Move only the files to the final image that are really needed
-COPY start.sh package*.json LICENSE SECURITY.md ./
-COPY --from=production-dependencies /kompla-app/node_modules/ ./node_modules/
-COPY --from=build /kompla-app/build/server ./build/server
-COPY --from=build /kompla-app/build/client ./build/client
+COPY --chown=node:node start.sh package*.json LICENSE SECURITY.md ./
+COPY --chown=node:node --from=production-dependencies /kompla-app/node_modules/ ./node_modules/
+COPY --chown=node:node --from=build /kompla-app/build/server ./build/server
+COPY --chown=node:node --from=build /kompla-app/build/client ./build/client
 
 EXPOSE 3000
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]


### PR DESCRIPTION
To provide context for the removal of the `--chown` args within https://github.com/digitalservicebund/a2j-kommunikationsplattform/pull/60

![sonarqube-info](https://github.com/user-attachments/assets/cbc5628e-736d-47d4-82b4-6d57fd03f1ea)
