### PR TITLE
Implemented the final BRAK call to authenticate

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,5 +1,6 @@
 import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
-import { data, Link } from "@remix-run/react";
+import { data, Link, redirect } from "@remix-run/react";
+import { authorizeUser } from "~/services/brakAuth.server";
 import { getSession } from "~/services/session.server";
 
 export const meta: MetaFunction = () => {
@@ -18,12 +19,35 @@ export const meta: MetaFunction = () => {
 export async function loader({ request }: LoaderFunctionArgs) {
   // debugging:
   const session = await getSession(request.headers.get("Cookie"));
+
+  // Our redirect_uri is currently incorrectly configured to the index endpoint.
+  // We have requested this to be updated to the auth.callback endpoint, but it has not yet been done.
+  // As a workaround, we will call the authUser function here, which will call authorizeUser.
+  await authUser(request);
+
   const codeVerifier = session.get("code_verifier");
   const return_to = session.get("return_to");
   console.log("codeVerifier is", codeVerifier);
   console.log("return_to is", return_to);
 
   return data(null);
+}
+
+async function authUser(request: Request) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+
+  if (code) {
+    await authorizeUser(request)
+      .then((data) => {
+        console.log("authorizeUser then", data);
+        throw redirect("/dashboard");
+      })
+      .catch((error) => {
+        console.log("authorizeUser catch", error);
+        throw redirect("/error");
+      });
+  }
 }
 
 export default function Index() {


### PR DESCRIPTION
After signing in on the BEA portal, we are redirected to our `/` endpoint. This should actually be `/auth/callback`, however it's currently still incorrectly configured on the BEA portal. 

This change does the final step in the auth flow -> When we are redirected to `/`, if there is a `code` parameter in the url, we make the final POST to BEA, to get the access_token.