### PR TITLE
Refactor to make switching oath library easy

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -16,7 +16,7 @@ fileignoreconfig:
   - filename: app/config/config.server.ts
     checksum: b6a0e33089ec2984286d88f2cd36ae713e1f007c8555e3da2277f34578f8b085
   - filename: app/services/oauth.server.ts
-    checksum: 81b94381f2f47ff71afe9bc715fe6cdb56c0426e83ea326db0bec9b96c4c89e2
+    checksum: 176d4dddd55ec3106c1f720675afa18877af2e01e83798fc3b691f190d6a3bfd
 version: ""
 scopeconfig:
   - scope: node

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,6 +1,7 @@
 import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
 import { data, Link, redirect } from "@remix-run/react";
 import { authenticator } from "~/services/oauth.server";
+// import { authorizeUser } from "~/services/brakAuth.server";
 import { getSession } from "~/services/session.server";
 
 export const meta: MetaFunction = () => {
@@ -23,8 +24,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
   // Our redirect_uri is currently incorrectly configured to the index endpoint.
   // We have requested this to be updated to the auth.callback endpoint, but it has not yet been done.
   // As a workaround, we will call the authUser function here, which will call authorizeUser.
-  // await authUser(request);
 
+  // Using the openid-connect library:
+  // await authUserOpenId(request);
+
+  // Using the remix-oauth library:
+  await authUserRemixOAuth(request);
+
+  const codeVerifier = session.get("code_verifier");
+  const return_to = session.get("return_to");
+  console.log("codeVerifier is", codeVerifier);
+  console.log("return_to is", return_to);
+
+  return data(null);
+}
+
+async function authUserRemixOAuth(request: Request) {
   const url = new URL(request.url);
   const code = url.searchParams.get("code");
   if (code) {
@@ -35,14 +50,24 @@ export async function loader({ request }: LoaderFunctionArgs) {
       console.error("Authentication error:", error);
     }
   }
-
-  const codeVerifier = session.get("code_verifier");
-  const return_to = session.get("return_to");
-  console.log("codeVerifier is", codeVerifier);
-  console.log("return_to is", return_to);
-
-  return data(null);
 }
+
+// async function authUserOpenId(request: Request) {
+//   const url = new URL(request.url);
+//   const code = url.searchParams.get("code");
+
+//   if (code) {
+//     await authorizeUser(request)
+//       .then((data) => {
+//         console.log("authorizeUser then", data);
+//         throw redirect("/dashboard");
+//       })
+//       .catch((error) => {
+//         console.log("authorizeUser catch", error);
+//         throw redirect("/error");
+//       });
+//   }
+// }
 
 export default function Index() {
   return (

--- a/app/routes/login.bea.tsx
+++ b/app/routes/login.bea.tsx
@@ -5,7 +5,11 @@ import { authenticator } from "~/services/oauth.server";
 export const loader: LoaderFunction = async ({ request }) => {
   console.log("BeaLogin loader...");
 
-  await authenticator.authenticate("provider-name", request);
+  // Using the openid-connect library:
+  // await requireUserSession(request);
+
+  // Using the remix-oauth library:
+  await authenticator.authenticate("bea", request);
 
   return null;
 };

--- a/app/services/oauth.server.ts
+++ b/app/services/oauth.server.ts
@@ -16,12 +16,8 @@ authenticator.use(
       clientId: config().BRAK_IDP_OIDC_CLIENT_ID,
       clientSecret: config().BRAK_IDP_OIDC_CLIENT_SECRET,
 
-      // authorizationEndpoint: `${config().BRAK_IDP_OIDC_ISSUER}/auth`,
-      authorizationEndpoint: `https://schulung.bea-brak.de/auth/realms/brak/protocol/openid-connect/auth`,
-
-      // tokenEndpoint: `${config().BRAK_IDP_OIDC_ISSUER}/token`,
-      tokenEndpoint: `https://schulung.bea-brak.de/auth/realms/brak/protocol/openid-connect/token`,
-
+      authorizationEndpoint: `${config().BRAK_IDP_OIDC_ISSUER}/auth`,
+      tokenEndpoint: `${config().BRAK_IDP_OIDC_ISSUER}/token`,
       redirectURI: `${config().BRAK_IDP_OIDC_REDIRECT_URI}`,
 
       //   tokenRevocationEndpoint: "https://provider.com/oauth2/revoke", // optional
@@ -38,5 +34,5 @@ authenticator.use(
   ),
   // this is optional, but if you setup more than one OAuth2 instance you will
   // need to set a custom name to each one
-  "provider-name",
+  "bea",
 );


### PR DESCRIPTION
We're currently getting an `unauthorized_user` error response from BEA. Unsure if it's our implementation or an issue on their side, I implemented the `remix-oauth2` library. We get the same error using this library.

This PR just makes it easier to switch between the two libraries, since I want to run it by @manuelpuchta before making the switch.