### PR TITLE
Return session cookie headers

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -27,9 +27,15 @@ async function authUserRemixOAuth(request: Request) {
   const code = url.searchParams.get("code");
   if (code) {
     try {
-      let user = await authenticator.authenticate("bea", request);
-      console.log("user is", user);
-      throw redirect("/dashboard");
+      let authenticationResponse = await authenticator.authenticate(
+        "bea",
+        request,
+      );
+      return redirect("/dashboard", {
+        headers: {
+          "Set-Cookie": authenticationResponse.sessionCookieHeader,
+        },
+      });
     } catch (error) {
       console.error("Authentication error:", error);
     }

--- a/app/services/session.server.ts
+++ b/app/services/session.server.ts
@@ -17,11 +17,15 @@ const { getSession, commitSession, destroySession } =
 export { getSession, commitSession, destroySession };
 
 // Once a user has authenticated with the OAuth2 strategy, we create a session for the user.
-export const createUserSession = async (user: User, request: Request) => {
+export const createUserSession = async (
+  accessToken: string,
+  expiresAt: number,
+  request: Request,
+) => {
   const session = await getSession(request.headers.get("Cookie"));
 
-  session.set("accessToken", user.accessToken);
-  session.set("expiresAt", user.expiresAt);
+  session.set("accessToken", accessToken);
+  session.set("expiresAt", expiresAt);
 
   return commitSession(session);
 };


### PR DESCRIPTION
The session cookie is not being created at the moment. This PR returns the session cookie header in the authenticate result and sets it as part of the redirect to the dashboard.