### PR TITLE
Implemented `/auth/callback` and minor type refactor

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -9,14 +9,12 @@ fileignoreconfig:
     checksum: 3f194ddcbbfc8f9ac2a1655dcd288be0df200b3a285e1c96a5765b9664c1f88d
   - filename: .env.example
     checksum: e4f39c1718c11d16be854b2ff85c9bfb1d6ea9d5d1fafa3945515b5b458f0dcc
-  - filename: app/services/brakAuth.server.ts
-    checksum: d0ed7c5f8143376083b00304d514096728f6455e98aa2dfbe57e260868b28888
   - filename: app/config/config.server.ts
     checksum: 3e1bcb8f961ca98c3c018e9ea0eb3abbbce7b071f9cf7b0428b7c8be5f29e947
-  - filename: app/services/oauth.server.ts
-    checksum: 8adeb6ed54f89b211c51775ef5ee8c7237271b5e791884a9d6691bf24599786c
   - filename: app/services/session.server.ts
-    checksum: 3bd11eb583e1d75872148c2bf127c6eba067084379173b4f53fa83fc5a820cda
+    checksum: 53b3fb2c0f37f106048ea9bbe6cd4634686ee4035882d3ccedd50b0fd396b83c
+  - filename: app/services/oauth.server.ts
+    checksum: c7cf1c465b0a0a4eb5de3d84ea18b60f207ca622d989980cdb27ed9a5cf7a110
 version: ""
 scopeconfig:
   - scope: node

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,6 +1,6 @@
 import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
 import { data, Link, redirect } from "@remix-run/react";
-import { authenticator } from "~/services/oauth.server";
+import { AuthenticationProvider, authenticator } from "~/services/oauth.server";
 
 export const meta: MetaFunction = () => {
   return [
@@ -26,7 +26,7 @@ async function authUserRemixOAuth(request: Request) {
   if (code) {
     try {
       let authenticationResponse = await authenticator.authenticate(
-        "bea",
+        AuthenticationProvider.BEA,
         request,
       );
       return redirect("/dashboard", {

--- a/app/routes/auth.callback.tsx
+++ b/app/routes/auth.callback.tsx
@@ -1,20 +1,24 @@
-import { data, redirect, type LoaderFunction } from "@remix-run/node";
-import { authenticator } from "~/services/oauth.server";
+import { redirect, type LoaderFunction } from "@remix-run/node";
+import { AuthenticationProvider, authenticator } from "~/services/oauth.server";
 
-// needs to be done on root URL at the moment (redirect_url update needed by BRAK)
 export const loader: LoaderFunction = async ({ request }) => {
-  await authenticator
-    .authenticate("bea", request)
-    .then((data) => {
-      console.log("authorizeUser then", data);
-      throw redirect("/dashboard");
+  const authenticationProvider = AuthenticationProvider.BEA;
+  return authenticator
+    .authenticate(authenticationProvider, request)
+    .then((authenticationResponse) => {
+      return redirect("/dashboard", {
+        headers: {
+          "Set-Cookie": authenticationResponse.sessionCookieHeader,
+        },
+      });
     })
     .catch((error) => {
-      console.log("authorizeUser catch", error);
+      console.log(
+        `Failed to authenticate user at : ${authenticationProvider}`,
+        error,
+      );
       throw redirect("/error");
     });
-
-  return data(null);
 };
 
 export default function AuthCallback() {

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,7 +1,7 @@
 import type { LoaderFunction } from "@remix-run/node";
-import { authenticator } from "~/services/oauth.server";
+import { AuthenticationProvider, authenticator } from "~/services/oauth.server";
 
 export const loader: LoaderFunction = async ({ request }) => {
-  await authenticator.authenticate("bea", request);
+  await authenticator.authenticate(AuthenticationProvider.BEA, request);
   return null;
 };

--- a/app/services/session.server.ts
+++ b/app/services/session.server.ts
@@ -1,6 +1,6 @@
 import { createCookieSessionStorage, redirect } from "@remix-run/node";
 import { config } from "~/config/config.server";
-import { User, UserSchema } from "./oauth.server";
+import type { AuthenticationContext } from "./oauth.server";
 
 const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({
@@ -33,7 +33,7 @@ export const createUserSession = async (
 // We retrieve the user session from the request headers and ensure that the session has not expired.
 export const getUserSession = async (
   request: Request,
-): Promise<User | null> => {
+): Promise<AuthenticationContext | null> => {
   const session = await getSession(request.headers.get("Cookie"));
   const accessToken = session.get("accessToken");
   const expiresAt = session.get("expiresAt");
@@ -43,18 +43,10 @@ export const getUserSession = async (
     return null;
   }
 
-  const user = {
+  return {
     accessToken,
     expiresAt,
   };
-
-  try {
-    const parsedUser = UserSchema.parse(user);
-    return parsedUser;
-  } catch (error) {
-    console.error("Error parsing user session", error);
-    return null;
-  }
 };
 
 export const requireUserSession = async (request: Request) => {


### PR DESCRIPTION
- Refactored Authentication result types to be more descriptive for what they're used for
- Implemented the /auth/callback route, so that the `redirect_uri` switch should be easy