### PR TITLE
Fix circular dependency with vulnerability scan

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -106,11 +106,11 @@ jobs:
           docker save ${{ env.IMAGE_NAME }}:${{ github.sha }} -o /tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar
           echo "Docker image saved to: /tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar"
 
-      - name: Send failure to Slack
-        uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
-        if: ${{ failure() }}
-        with:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # - name: Send failure to Slack
+      #   uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
+      #   if: ${{ failure() }}
+      #   with:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   audit-licenses:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -150,6 +150,8 @@ jobs:
   vulnerability-scan:
     uses: ./.github/workflows/scan.yml
     secrets: inherit
+    needs:
+      - build
 
   build-and-push-image:
     runs-on: ubuntu-latest
@@ -157,7 +159,7 @@ jobs:
     needs:
       - build
       - audit-licenses
-      # - vulnerability-scan
+      - vulnerability-scan
     permissions:
       contents: read
       id-token: write # This is used to complete the identity challenge with sigstore/fulcio..

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -157,7 +157,7 @@ jobs:
     needs:
       - build
       - audit-licenses
-      - vulnerability-scan
+      # - vulnerability-scan
     permissions:
       contents: read
       id-token: write # This is used to complete the identity challenge with sigstore/fulcio..

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -70,8 +70,8 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
 
-      - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
-        if: ${{ failure() }}
-        with:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # - name: Send status to Slack
+      #   uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
+      #   if: ${{ failure() }}
+      #   with:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Load cached Docker image
         id: load-docker-image
         run: |
-          IMAGE_PATH="/tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar"
+          IMAGE_PATH="/tmp/.docker-cache/${{ env.CONTAINER_IMAGE_NAME }}_${{ github.sha }}.tar"
 
           if docker load -i $IMAGE_PATH; then
             echo "docker-image-load-successful=true" >> $GITHUB_ENV

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -32,6 +32,21 @@ jobs:
             /tmp/.docker-cache
           key: ${{ runner.os }}-docker-${{ github.sha }}
 
+      - name: Load cached Docker image
+        id: load-docker-image
+        run: |
+          IMAGE_PATH="/tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar"
+
+          if docker load -i $IMAGE_PATH; then
+            echo "docker-image-load-successful=true" >> $GITHUB_ENV
+            echo "::set-output name=docker-image-load-successful::true"
+            echo "Docker image loaded from cache: $IMAGE_PATH"
+          else
+            echo "docker-image-load-successful=false" >> $GITHUB_ENV
+            echo "::set-output name=docker-image-load-successful::false"
+            echo "Docker image not found in cache: $IMAGE_PATH"
+          fi
+
       - name: Validate github workflow files to have pinned versions
         uses: digitalservicebund/github-actions-linter@09783a3d4e13424bc0caf1f7145f68bc6138688b # v0.1.11
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,7 @@ on:
 env:
   CONTAINER_REGISTRY: ghcr.io
   CONTAINER_IMAGE_NAME: ${{ github.repository }}
-  CONTAINER_IMAGE_VERSION: latest
+  CONTAINER_IMAGE_VERSION: ${{ github.ref == 'refs/heads/main' && 'latest' || github.sha }} # Use 'latest' for main, commit hash for PR or other branches
 
 jobs:
   vulnerability-scan:
@@ -25,6 +25,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Restore Docker image cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /tmp/.docker-cache
+          key: ${{ runner.os }}-docker-${{ github.sha }}
+
       - name: Validate github workflow files to have pinned versions
         uses: digitalservicebund/github-actions-linter@09783a3d4e13424bc0caf1f7145f68bc6138688b # v0.1.11
 
@@ -36,7 +43,7 @@ jobs:
           # Specify multiple registries: try default GitHub registry, if too many requests, use the aws mirror.
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
-          image-ref: ${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_IMAGE_NAME }}:${{ env.CONTAINER_IMAGE_VERSION }}
+          image-ref: ${{ env.CONTAINER_IMAGE_NAME }}:${{ env.CONTAINER_IMAGE_VERSION }}
           format: "sarif"
           # By default SARIF format enforces output of all vulnerabilities regardless of configured severities.
           # To override this set limit-severities-for-sarif to true.

--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -18,8 +18,8 @@ jobs:
         # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
         # enforced by digitalservicebund/github-actions/github-actions-linter
         uses: carhartl/talisman-secrets-scan-action@702fc5c52170632a568124896148a80f38521ac4 # v1.4.0
-      - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
-        if: ${{ failure() }}
-        with:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # - name: Send status to Slack
+      #   uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
+      #   if: ${{ failure() }}
+      #   with:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.talismanrc
+++ b/.talismanrc
@@ -4,6 +4,7 @@ fileignoreconfig:
   - filename: public/fonts/BundesSansWeb-BoldItalic.woff
     checksum: 446eff0044854604c36e380d186aab48077af382668430ad518ef49b37d4fa02
   - filename: SECURITY.md
+    checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
   - filename: .github/workflows/scan.yml
     checksum: 9ff9bdbfe552c09b24590f046ca35cc6bfd6f5d696e8920e9dd553a3921ce6c2
   - filename: .github/workflows/pipeline.yml

--- a/.talismanrc
+++ b/.talismanrc
@@ -6,7 +6,7 @@ fileignoreconfig:
   - filename: SECURITY.md
     checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
   - filename: .github/workflows/pipeline.yml
-    checksum: 78658e18adba259cc80c98523b00fa621680fc26dd5b4c61de6b6d0c34dd2d82
+    checksum: 83b504bdc699989c30c4534220fc811c5acd9968f1743269f6abb010dffd3077
   - filename: .env.example
     checksum: e4f39c1718c11d16be854b2ff85c9bfb1d6ea9d5d1fafa3945515b5b458f0dcc
   - filename: app/config/config.server.ts

--- a/.talismanrc
+++ b/.talismanrc
@@ -6,7 +6,7 @@ fileignoreconfig:
   - filename: SECURITY.md
     checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
   - filename: .github/workflows/scan.yml
-    checksum: a6fe795cca1815f0a8e282385312233ca7b4baeea5ed02c30f8ee49ba3982e1a
+    checksum: bf408063c6c416dee9f433a01d722bb37d5ff242ba5627929904f32f9a20f1a1
   - filename: .github/workflows/pipeline.yml
     checksum: 7024e4c95bfa53af1af50706e907ec6c39d44a979151fcc4331bfb2cb1c71014
   - filename: .env.example

--- a/.talismanrc
+++ b/.talismanrc
@@ -8,7 +8,6 @@ fileignoreconfig:
     checksum: 9ff9bdbfe552c09b24590f046ca35cc6bfd6f5d696e8920e9dd553a3921ce6c2
   - filename: .github/workflows/pipeline.yml
     checksum: 7024e4c95bfa53af1af50706e907ec6c39d44a979151fcc4331bfb2cb1c71014
-    checksum: 83b504bdc699989c30c4534220fc811c5acd9968f1743269f6abb010dffd3077
   - filename: .env.example
     checksum: e4f39c1718c11d16be854b2ff85c9bfb1d6ea9d5d1fafa3945515b5b458f0dcc
   - filename: app/config/config.server.ts

--- a/.talismanrc
+++ b/.talismanrc
@@ -6,7 +6,7 @@ fileignoreconfig:
   - filename: SECURITY.md
     checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
   - filename: .github/workflows/pipeline.yml
-    checksum: dc40f4db09eb6dda55c99c6b9a3a96ef4bf4591f4fbbae14e7991385ab9d114f
+    checksum: 78658e18adba259cc80c98523b00fa621680fc26dd5b4c61de6b6d0c34dd2d82
   - filename: .env.example
     checksum: e4f39c1718c11d16be854b2ff85c9bfb1d6ea9d5d1fafa3945515b5b458f0dcc
   - filename: app/config/config.server.ts

--- a/.talismanrc
+++ b/.talismanrc
@@ -4,8 +4,10 @@ fileignoreconfig:
   - filename: public/fonts/BundesSansWeb-BoldItalic.woff
     checksum: 446eff0044854604c36e380d186aab48077af382668430ad518ef49b37d4fa02
   - filename: SECURITY.md
-    checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
+  - filename: .github/workflows/scan.yml
+    checksum: 9ff9bdbfe552c09b24590f046ca35cc6bfd6f5d696e8920e9dd553a3921ce6c2
   - filename: .github/workflows/pipeline.yml
+    checksum: 7024e4c95bfa53af1af50706e907ec6c39d44a979151fcc4331bfb2cb1c71014
     checksum: 83b504bdc699989c30c4534220fc811c5acd9968f1743269f6abb010dffd3077
   - filename: .env.example
     checksum: e4f39c1718c11d16be854b2ff85c9bfb1d6ea9d5d1fafa3945515b5b458f0dcc

--- a/.talismanrc
+++ b/.talismanrc
@@ -6,7 +6,7 @@ fileignoreconfig:
   - filename: SECURITY.md
     checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
   - filename: .github/workflows/scan.yml
-    checksum: 9ff9bdbfe552c09b24590f046ca35cc6bfd6f5d696e8920e9dd553a3921ce6c2
+    checksum: a6fe795cca1815f0a8e282385312233ca7b4baeea5ed02c30f8ee49ba3982e1a
   - filename: .github/workflows/pipeline.yml
     checksum: 7024e4c95bfa53af1af50706e907ec6c39d44a979151fcc4331bfb2cb1c71014
   - filename: .env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ FROM node:20.18.3-alpine3.20
 # TODO: Check https://hub.docker.com/r/library/node/tags?name=alpine3.20
 # - Remove npm update when CVE-2024-21538 is fixed (https://scout.docker.com/vulnerabilities/id/CVE-2024-21538?s=github)
 RUN npm update -g npm && npm cache clean --force && \
+    apk update && apk add --no-cache libcrypto3=3.3.3-r0 libssl3=3.3.3-r0 && \
     apk add --no-cache dumb-init && rm -rf /var/cache/apk/*
 
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ FROM node:20.18.3-alpine3.20.6
 # TODO: Check https://hub.docker.com/r/library/node/tags?name=alpine3.20
 # - Remove npm update when CVE-2024-21538 is fixed (https://scout.docker.com/vulnerabilities/id/CVE-2024-21538?s=github)
 RUN npm update -g npm && npm cache clean --force && \
+    apk upgrade -a && \
     apk add --no-cache dumb-init && rm -rf /var/cache/apk/*
 
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,11 @@ COPY . ./
 RUN npm run build
 
 # Final image that runs the app
-FROM node:20.18.3-alpine3.20
+FROM node:20.18.3-alpine3.20.6
 
 # TODO: Check https://hub.docker.com/r/library/node/tags?name=alpine3.20
 # - Remove npm update when CVE-2024-21538 is fixed (https://scout.docker.com/vulnerabilities/id/CVE-2024-21538?s=github)
 RUN npm update -g npm && npm cache clean --force && \
-    apk update && apk add --no-cache libcrypto3=3.3.3-r0 libssl3=3.3.3-r0 && \
     apk add --no-cache dumb-init && rm -rf /var/cache/apk/*
 
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY . ./
 RUN npm run build
 
 # Final image that runs the app
-FROM node:20.18.3-alpine3.20.6
+FROM node:20.18.3-alpine3.21
 
 # TODO: Check https://hub.docker.com/r/library/node/tags?name=alpine3.20
 # - Remove npm update when CVE-2024-21538 is fixed (https://scout.docker.com/vulnerabilities/id/CVE-2024-21538?s=github)

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM node:20.18.3-alpine3.20.6
 # TODO: Check https://hub.docker.com/r/library/node/tags?name=alpine3.20
 # - Remove npm update when CVE-2024-21538 is fixed (https://scout.docker.com/vulnerabilities/id/CVE-2024-21538?s=github)
 RUN npm update -g npm && npm cache clean --force && \
-    apk upgrade -a && \
+    apk update && apk upgrade -a && apk cache clean && \
     apk add --no-cache dumb-init && rm -rf /var/cache/apk/*
 
 USER node


### PR DESCRIPTION
This PR fixes the circular dependency with the `vulnerability-scan` job.

The problem is that this step always runs against the `latest` docker image. If there is a vulnerability in the `latest` image, you are unable to push the fix, since the `vulnerability-scan` job blocks you from pushing the fixed image.

I decided not to merge this PR, since it means that the `vulnerability-scan` is now dependent on the `build` job, and can no longer run in parallel. This increases our build times by ~1 min for every build. 

My proposed solution when fixing a vulnerability issue (since they don't happen that often), is to just comment out the `vulnerability-scan` job when making the fix, and uncommenting it once the image has been pushed. Example PR: https://github.com/digitalservicebund/a2j-kommunikationsplattform/pull/118/files