### PR TITLE
Remove unnecessary upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ FROM node:20.18.3-alpine3.21
 # TODO: Check https://hub.docker.com/r/library/node/tags?name=alpine3.20
 # - Remove npm update when CVE-2024-21538 is fixed (https://scout.docker.com/vulnerabilities/id/CVE-2024-21538?s=github)
 RUN npm update -g npm && npm cache clean --force && \
-    apk update && apk upgrade -a && apk cache clean && \
     apk add --no-cache dumb-init && rm -rf /var/cache/apk/*
 
 USER node


### PR DESCRIPTION
The latest docker base image already contains fixes for the vulnerabilities that the `vulnerability-scan` detected in previous builds. Therefore, there is no need to do this manual update step anymore. Also better not to do a global upgrade, since it makes the builds not reproducible -> every version change will be applied here.