### PR TITLE
Reimplement file upload saves to disk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,12 @@ FROM node:20.18.3-alpine3.21
 RUN npm update -g npm && npm cache clean --force && \
     apk add --no-cache dumb-init && rm -rf /var/cache/apk/*
 
+
+# Create tmp directory and make it writable.
+# This is needed for the application to write file uploads to the tmp directory
+#   before they are sent to the Justiz-Backend-API
+RUN mkdir -p /tmp && chmod -R 777 /tmp
+
 USER node
 ENV NODE_ENV=production
 ENV npm_config_cache=/tmp/.npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN npm update -g npm && npm cache clean --force && \
 # Create tmp directory and make it writable.
 # This is needed for the application to write file uploads to the tmp directory
 #   before they are sent to the Justiz-Backend-API
-RUN mkdir -p /tmp && chmod -R 777 /tmp
+RUN mkdir -p /tmp && chown node:node /tmp && chmod 700 /tmp
 
 USER node
 ENV NODE_ENV=production

--- a/app/services/fileupload.server.ts
+++ b/app/services/fileupload.server.ts
@@ -2,7 +2,7 @@ import {
   unstable_composeUploadHandlers,
   unstable_createMemoryUploadHandler,
   unstable_parseMultipartFormData,
-  // unstable_createFileUploadHandler,
+  unstable_createFileUploadHandler,
 } from "@remix-run/node";
 
 export async function getFormDataFromRequest(
@@ -10,11 +10,11 @@ export async function getFormDataFromRequest(
 ): Promise<FormData> {
   // https://remix.run/docs/en/main/guides/file-uploads
   const uploadHandler = unstable_composeUploadHandlers(
-    // unstable_createFileUploadHandler({
-    //   maxPartSize: 6_000_000_0, // 60MB
-    //   file: ({ filename }) => filename,
-    //   avoidFileConflicts: false,
-    // }),
+    unstable_createFileUploadHandler({
+      maxPartSize: 6_000_000_0, // 60MB
+      file: ({ filename }) => filename,
+      avoidFileConflicts: false,
+    }),
     unstable_createMemoryUploadHandler({
       maxPartSize: 6_000_000_0, // 60MB
     }),


### PR DESCRIPTION
There was an issue that we don't have `write` access to the `tmp` directory when the app is running in Docker. As a quick workaround, I made it that files are kept in memory instead of being stored on disk, before they are sent to the `Justiz-Backend-API`. This only works with a low amount of traffic, since the memory will very quickly be filled up if many users are submitting files at the same time. 

This is a fix to grant `write` access to the tmp directory so that we can save the files there.