### PR TITLE
Use fileupload volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,6 @@ FROM node:20.18.3-alpine3.21
 RUN npm update -g npm && npm cache clean --force && \
     apk add --no-cache dumb-init && rm -rf /var/cache/apk/*
 
-
-# Create tmp directory and make it writable.
-# This is needed for the application to write file uploads to the tmp directory
-#   before they are sent to the Justiz-Backend-API
-RUN mkdir -p /tmp && chown node:node /tmp && chmod 770 /tmp
-
 USER node
 ENV NODE_ENV=production
 ENV npm_config_cache=/tmp/.npm

--- a/app/config/config.server.ts
+++ b/app/config/config.server.ts
@@ -7,6 +7,7 @@ interface Config {
   BRAK_IDP_OIDC_ISSUER: string;
   BRAK_IDP_OIDC_REDIRECT_URI: string;
   JUSTIZ_BACKEND_API_URL: string;
+  FILE_UPLOAD_DIRECTORY: string;
 }
 
 let instance: Config | undefined = undefined;
@@ -29,6 +30,8 @@ export function config(): Config {
         process.env.BRAK_IDP_OIDC_REDIRECT_URI?.trim() ?? "",
       JUSTIZ_BACKEND_API_URL:
         process.env.JUSTIZ_BACKEND_API_URL?.trim() ?? "https://kompla.sinc.de",
+      FILE_UPLOAD_DIRECTORY:
+        process.env.FILE_UPLOAD_DIRECTORY?.trim() ?? "/fileuploads",
     };
   }
 

--- a/app/services/fileupload.server.ts
+++ b/app/services/fileupload.server.ts
@@ -2,19 +2,21 @@ import {
   unstable_composeUploadHandlers,
   unstable_createMemoryUploadHandler,
   unstable_parseMultipartFormData,
-  // unstable_createFileUploadHandler,
+  unstable_createFileUploadHandler,
 } from "@remix-run/node";
+import { config } from "~/config/config.server";
 
 export async function getFormDataFromRequest(
   request: Request,
 ): Promise<FormData> {
   // https://remix.run/docs/en/main/guides/file-uploads
   const uploadHandler = unstable_composeUploadHandlers(
-    // unstable_createFileUploadHandler({
-    //   maxPartSize: 6_000_000_0, // 60MB
-    //   file: ({ filename }) => filename,
-    //   avoidFileConflicts: false,
-    // }),
+    unstable_createFileUploadHandler({
+      maxPartSize: 6_000_000_0, // 60MB,
+      directory: config().FILE_UPLOAD_DIRECTORY,
+      file: ({ filename }) => filename,
+      avoidFileConflicts: false,
+    }),
     unstable_createMemoryUploadHandler({
       maxPartSize: 6_000_000_0, // 60MB
     }),

--- a/tests/unit/services/fileupload.spec.ts
+++ b/tests/unit/services/fileupload.spec.ts
@@ -5,6 +5,7 @@ import { getFormDataFromRequest } from "~/services/fileupload.server";
 
 describe("File Upload Service", () => {
   it("should extract files from multipart form data correctly", async () => {
+    process.env.FILE_UPLOAD_DIRECTORY = "/tmp";
     const fileName = `file_${Date.now()}.xml`;
     const fileContent = "file content";
     const file = new File([fileContent], fileName, { type: "text/xml" });


### PR DESCRIPTION
Use the `emptyDir` volume to store uploaded files instead of `tmp` directory