### PR TITLE
Refactor endpoints to match swagger

### DIFF
--- a/app/services/justizbackend.server.ts
+++ b/app/services/justizbackend.server.ts
@@ -286,7 +286,7 @@ class JustizBackendServiceImpl implements JustizBackendService {
     limit: number,
     offset: number,
   ): Promise<AllDokumenteResponse> {
-    const url = `${this.baseUrl}/api/v1/verfahren/${verfahrenId}/dokumente/${aktenteilId}?limit=${limit}&offset=${offset}`;
+    const url = `${this.baseUrl}/api/v1/verfahren/${verfahrenId}/akte/${aktenteilId}/dokumente?limit=${limit}&offset=${offset}`;
     try {
       const response = await fetch(url, {
         method: "GET",
@@ -328,7 +328,7 @@ class JustizBackendServiceImpl implements JustizBackendService {
     verfahrenId: string,
     dokumentId: string,
   ): Promise<DokumentFile | undefined> {
-    const url = `${this.baseUrl}/api/v1/verfahren/${verfahrenId}/dokument/${dokumentId}`;
+    const url = `${this.baseUrl}/api/v1/verfahren/${verfahrenId}/akte/dokumente/${dokumentId}`;
     try {
       const response = await fetch(url, {
         method: "GET",


### PR DESCRIPTION
Justiz-Backend-API changed the structure of some endpoints. They haven't yet deployed this change to avoid breaking the dev env before the Demo. They will inform us when they'll deploy, as it is a breaking change.