### PR TITLE
Ignore health check in sentry

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -18,6 +18,7 @@ if (SENTRY_DSN !== undefined) {
     tracesSampleRate: 1.0, //  Capture 100% of the transactions
 
     tracePropagationTargets: [
+      /^(?!\/\.well-known\/health$).*$/, // Exclude /.well-known/health
       /^\//, //  This enables trace propagation for all relative paths on the same domain.
       /^https:\/\/kompla\.sinc\.de\//,
     ],

--- a/app/instrument.server.mjs
+++ b/app/instrument.server.mjs
@@ -3,4 +3,9 @@ import * as Sentry from "@sentry/react-router";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0, // Capture 100% of the transactions
+  tracePropagationTargets: [
+    /^(?!\/\.well-known\/health$).*$/, // Exclude /.well-known/health
+    /^\//, // This enables trace propagation for all relative paths on the same domain.
+    /^https:\/\/kompla\.sinc\.de\//,
+  ],
 });


### PR DESCRIPTION
Sentry is getting spammed with ~30 requests per minute due to k8s hitting the healthcheck endpoint to see if the service is up. This should ignore this endpoint from traces