### PR TITLE
KOMMPLA-640: Redirect Link Court User Research Sign Up

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -37,6 +37,9 @@ export default [
     route("hilfe-und-kontakt", "./routes/hilfe-und-kontakt.tsx"),
     route("open-source", "./routes/open-source.tsx"),
     route("weitere-informationen", "./routes/weitere-informationen.tsx"),
+
+    // redirect links
+    route("link/*", "./routes/link.$.tsx"),
   ]),
 
   // Kubernetes health check

--- a/app/routes/__test__/link.test.ts
+++ b/app/routes/__test__/link.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { loader } from "~/routes/link.$";
+
+describe("link loader", () => {
+  it('should redirect to "anmeldung-teilnahme-kommunikationsplattform" to the correct path', () => {
+    const mockArgs = {
+      params: { "*": "anmeldung-teilnahme-kommunikationsplattform" },
+      request: new Request(
+        "https://test.com/anmeldung-teilnahme-kommunikationsplattform",
+      ),
+      context: {},
+    };
+
+    const response = loader(mockArgs);
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "https://app.formbricks.com/s/cmf2nqcww661jtl01u8a5uo4n",
+    );
+  });
+
+  it("should throw a 404 response when no params are provided", () => {
+    const mockArgs = {
+      params: {},
+      request: new Request("https://test.com"),
+      context: {},
+    };
+    expect(() => loader(mockArgs)).toThrowError();
+
+    try {
+      loader(mockArgs);
+    } catch (error) {
+      expect(error).toBeInstanceOf(Response);
+      expect((error as Response).status).toBe(404);
+    }
+  });
+  it("should throw a 404 response for an unknown site", () => {
+    const mockArgs = {
+      params: { "*": "unknown-site" },
+      request: new Request("https://test.com/unknown-site"),
+      context: {},
+    };
+    expect(() => loader(mockArgs)).toThrowError();
+
+    try {
+      loader(mockArgs);
+    } catch (error) {
+      expect(error).toBeInstanceOf(Response);
+      expect((error as Response).status).toBe(404);
+    }
+  });
+});

--- a/app/routes/link.$.tsx
+++ b/app/routes/link.$.tsx
@@ -1,0 +1,14 @@
+import { type LoaderFunctionArgs, redirect } from "react-router";
+
+const redirectionMap = {
+  "anmeldung-teilnahme-kommunikationsplattform":
+    "https://app.formbricks.com/s/cmf2nqcww661jtl01u8a5uo4n",
+};
+
+export function loader({ params }: LoaderFunctionArgs) {
+  const requestedSite = params["*"];
+  if (!requestedSite || !(requestedSite in redirectionMap)) {
+    throw new Response(null, { status: 404 });
+  }
+  return redirect(redirectionMap[requestedSite as keyof typeof redirectionMap]);
+}


### PR DESCRIPTION
@manuelpuchta & @joschka 

Just created a small feature for redirecting users to specific site, see [this](https://digitalservicebund.atlassian.net/browse/KOMMPLA-640) Jira ticket.

### Redirect feature implementation

* Added a new catch-all route `link/*` in `app/routes.ts` to handle redirect links.
* Implemented the loader logic in `app/routes/link.$.tsx` that maps specific link paths (currently `anmeldung-teilnahme-kommunikationsplattform`) to external URLs and handles 404 errors for unknown or missing paths.

### Testing

* Created tests in `app/routes/__test__/link.test.ts` to verify correct redirection, and proper handling of unknown or missing parameters with 404 responses.

### Possible future refactoring

* Since our redirect link does not contain sensitive information in this case, it should be fine as is. However, in the future, we may want to consider storing the link in an environment variable for added flexibility and security. What are your thoughts?