### PR TITLE
KOMMPLA-662: GitHub CI set output update (soon deprecated)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -185,12 +185,10 @@ jobs:
           IMAGE_PATH="/tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar"
 
           if docker load -i $IMAGE_PATH; then
-            echo "docker-image-load-successful=true" >> $GITHUB_ENV
-            echo "::set-output name=docker-image-load-successful::true"
+            echo "docker-image-load-successful=true" >> $GITHUB_OUTPUT
             echo "Docker image loaded from cache: $IMAGE_PATH"
           else
-            echo "docker-image-load-successful=false" >> $GITHUB_ENV
-            echo "::set-output name=docker-image-load-successful::false"
+            echo "docker-image-load-successful=false" >> $GITHUB_OUTPUT
             echo "Docker image not found in cache: $IMAGE_PATH"
           fi
 

--- a/.talismanrc
+++ b/.talismanrc
@@ -2,7 +2,7 @@ fileignoreconfig:
   - filename: SECURITY.md
     checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
   - filename: .github/workflows/pipeline.yml
-    checksum: fdc74c2957ef7f57e7a1bfd50599fa5730eacf829d8e02d8449fc9def8ab3706
+    checksum: 431d1d2cb0a9c333b12b255390d4e214552113b98da90d98f608bf3a8b720366
   - filename: .env.example
     checksum: da4e98ae25d8ead27bd2e93dcfabe316de08b4400933fb60de5f06e1cec111a0
   - filename: package-lock.json


### PR DESCRIPTION
Upgrades the (cached) docker image loading step.

See:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#environment-files