### PR TITLE
KOMMPLA-490: Create the option of text maintenance using a translation file

### DIFF
--- a/app/components/Kopfzeile.static.tsx
+++ b/app/components/Kopfzeile.static.tsx
@@ -1,4 +1,7 @@
+import { useTranslations } from "~/services/translations/context";
+
 export default function Kopfzeile() {
+  const { labels } = useTranslations();
   return (
     <div className="kern-kopfzeile">
       <div className="kern-container">
@@ -15,7 +18,7 @@ export default function Kopfzeile() {
             </svg>
           </span>
           <span className="kern-kopfzeile__label">
-            Offizielle Website – Bundesrepublik Deutschland
+            {labels.KOPFZEILE_LABEL}
           </span>
         </div>
       </div>

--- a/app/components/Logo.static.tsx
+++ b/app/components/Logo.static.tsx
@@ -1,11 +1,14 @@
+import { useTranslations } from "~/services/translations/context";
+
 export default function Logo() {
+  const { labels } = useTranslations();
   return (
     <div className="gap-kern-space-small flex flex-row flex-wrap items-center justify-center break-all">
       <span
         className="kern-icon kern-icon--network_node kern-icon--large"
         aria-hidden
       />
-      <h1 className="kern-heading-large">Kommunikationsplattform</h1>
+      <h1 className="kern-heading-large">{labels.LOGO_LABEL}</h1>
     </div>
   );
 }

--- a/app/components/Navigation.static.tsx
+++ b/app/components/Navigation.static.tsx
@@ -1,42 +1,44 @@
 import { Form } from "react-router";
 import { LogoutType } from "~/routes/action.logout-user";
+import { useTranslations } from "~/services/translations/context";
 
 const LogoutButton = () => {
+  const { buttons } = useTranslations();
   return (
     <Form method="post" action="/action/logout-user">
       <input type="hidden" name="logoutType" value={LogoutType.ByUser} />
       <button type="submit" className="kern-link cursor-pointer bg-transparent">
         <span className="kern-icon kern-icon--close kern-icon--default"></span>
-        <span>Abmelden</span>
+        <span>{buttons.ABMELDEN_BUTTON}</span>
       </button>
     </Form>
   );
 };
 
-const navigationLinksList = [
-  {
-    name: "Übersicht",
-    iconName: "kern-icon--home",
-    url: `/`,
-  },
-  {
-    name: "Verfahren",
-    iconName: "kern-icon--icon--storage",
-    url: `/verfahren`,
-  },
-  {
-    name: "Mitteilungen",
-    iconName: "kern-icon--mail",
-    url: "#",
-  },
-  {
-    name: "Kalender",
-    iconName: "kern-icon--calendar-today",
-    url: "#",
-  },
-];
-
 export default function Navigation() {
+  const { labels } = useTranslations();
+  const navigationLinksList = [
+    {
+      name: labels.UEBERSICHT_LABEL,
+      iconName: "kern-icon--home",
+      url: `/`,
+    },
+    {
+      name: labels.VERFAHREN_LABEL,
+      iconName: "kern-icon--icon--storage",
+      url: `/verfahren`,
+    },
+    {
+      name: labels.MITTEILUNGEN_LABEL,
+      iconName: "kern-icon--mail",
+      url: "#",
+    },
+    {
+      name: labels.KALENDER_LABEL,
+      iconName: "kern-icon--calendar-today",
+      url: "#",
+    },
+  ];
   return (
     <nav>
       <ul className="gap-kern-space-x-large my-0 list-none items-center justify-between pl-0 md:flex xl:flex-wrap">

--- a/app/components/PageFooter.tsx
+++ b/app/components/PageFooter.tsx
@@ -1,13 +1,13 @@
 import { Link } from "react-router";
-import { de } from "~/services/translations/de";
+import { useTranslations } from "~/services/translations/context";
 
 export default function PageFooter() {
-  const { FOOTER_ARIA_LABEL, PROJECT_DESCRIPTION } = de.footer;
+  const { labels, descriptions } = useTranslations();
   return (
     <footer className="mt-kern-space-x-large">
       <nav
         className="gap-x-kern-space-default flex flex-row flex-wrap justify-center"
-        aria-label={FOOTER_ARIA_LABEL}
+        aria-label={labels.FOOTER_ARIA_LABEL}
       >
         <Link to="/datenschutz" className="kern-link">
           Datenschutz
@@ -30,7 +30,7 @@ export default function PageFooter() {
       </nav>
       <div className="mt-kern-space-default mb-kern-space-x-large text-center">
         <p className="kern-body kern-body--small kern-body--muted">
-          {PROJECT_DESCRIPTION}
+          {descriptions.PROJECT_DESCRIPTION}
         </p>
       </div>
     </footer>

--- a/app/components/PageFooter.tsx
+++ b/app/components/PageFooter.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router";
 import { useTranslations } from "~/services/translations/context";
 
 export default function PageFooter() {
-  const { labels, descriptions } = useTranslations();
+  const { labels, descriptions, contentLinkLabels } = useTranslations();
   return (
     <footer className="mt-kern-space-x-large">
       <nav
@@ -10,22 +10,22 @@ export default function PageFooter() {
         aria-label={labels.FOOTER_ARIA_LABEL}
       >
         <Link to="/datenschutz" className="kern-link">
-          Datenschutz
+          {contentLinkLabels.DATENSCHUTZ_LINK_LABEL}
         </Link>
         <Link to="/weitere-informationen" className="kern-link">
-          Weitere Informationen
+          {contentLinkLabels.WEITERE_INFORMATIONEN_LINK_LABEL}
         </Link>
         <Link to="/barrierefreiheit" className="kern-link">
-          Barrierefreiheit
+          {contentLinkLabels.BARRIEREFREIHEIT_LINK_LABEL}
         </Link>
         <Link to="/hilfe-und-kontakt" className="kern-link">
-          Hilfe und Kontakt
+          {contentLinkLabels.HILFE_UND_KONTAKT_LINK_LABEL}
         </Link>
         <Link to="/open-source" className="kern-link">
-          Open Source Code
+          {contentLinkLabels.OPEN_SOURCE_CODE_LINK_LABEL}
         </Link>
         <Link to="/impressum" className="kern-link">
-          Impressum
+          {contentLinkLabels.IMPRESSUM_LINK_LABEL}
         </Link>
       </nav>
       <div className="mt-kern-space-default mb-kern-space-x-large text-center">

--- a/app/components/PageFooter.tsx
+++ b/app/components/PageFooter.tsx
@@ -1,10 +1,8 @@
 import { Link } from "react-router";
-
-export const PROJECT_DESCRIPTION =
-  "Ein Onlineprojekt der DigitalService GmbH des Bundes in Zusammenarbeit mit der BRAK, SINC und im Auftrag des BMJV.";
-export const FOOTER_ARIA_LABEL = "Rechtliche und weiterführende Informationen";
+import { de } from "~/services/translations/de";
 
 export default function PageFooter() {
+  const { FOOTER_ARIA_LABEL, PROJECT_DESCRIPTION } = de.footer;
   return (
     <footer className="mt-kern-space-x-large">
       <nav

--- a/app/components/PageMetadata.tsx
+++ b/app/components/PageMetadata.tsx
@@ -1,14 +1,4 @@
-const PLATFORM_TITLE = "Kommunikationsplattform | Justiz-Services";
-const PLATFORM_DESCRIPTION =
-  "Willkommen auf der Pilotplattform für den digitalen Austausch zwischen Gerichten und Verfahrensbeteiligten.";
-
-function pageTitle(text?: string) {
-  if (text) {
-    return `${text} | ${PLATFORM_TITLE}`;
-  } else {
-    return PLATFORM_TITLE;
-  }
-}
+import { useTranslations } from "~/services/translations/context";
 
 export type PageMetadataOptions = {
   title?: string;
@@ -16,10 +6,21 @@ export type PageMetadataOptions = {
 };
 
 export function PageMetadata({ title, description }: PageMetadataOptions) {
+  const { titles, descriptions } = useTranslations();
+  function pageTitle(text?: string) {
+    if (text) {
+      return `${text} | ${titles.PLATFORM_TITLE}`;
+    } else {
+      return titles.PLATFORM_TITLE;
+    }
+  }
   return (
     <>
       <title>{pageTitle(title)}</title>
-      <meta name="description" content={description || PLATFORM_DESCRIPTION} />
+      <meta
+        name="description"
+        content={description || descriptions.PLATFORM_DESCRIPTION}
+      />
     </>
   );
 }

--- a/app/components/Uebersicht.static.tsx
+++ b/app/components/Uebersicht.static.tsx
@@ -1,9 +1,11 @@
+import { useTranslations } from "~/services/translations/context";
 import WorkInProgressAlert from "./WorkInProgressAlert.static";
 
 export default function Uebersicht() {
+  const { labels } = useTranslations();
   return (
     <>
-      <h1 className="kern-heading-large">Übersicht</h1>
+      <h1 className="kern-heading-large">{labels.UEBERSICHT_LABEL}</h1>
       <WorkInProgressAlert />
     </>
   );

--- a/app/components/UserProfile.static.tsx
+++ b/app/components/UserProfile.static.tsx
@@ -1,4 +1,9 @@
+import { useTranslations } from "~/services/translations/context";
+
 export default function UserProfile() {
+  const { labels } = useTranslations();
+  // When we authenticate users, the user name would be fetched from the user session or context
+  const userName = "Kim Neumann";
   return (
     <div className="gap-kern-space-small flex flex-wrap items-center justify-end">
       <svg
@@ -13,7 +18,7 @@ export default function UserProfile() {
           fill="#404565"
         />
       </svg>
-      <p className="kern-body kern-body--muted">Angemeldet als: Kim Neumann</p>
+      <p className="kern-body kern-body--muted">{`${labels.LOGGED_IN_AS_LABEL}: ${userName}`}</p>
     </div>
   );
 }

--- a/app/components/UserProfile.static.tsx
+++ b/app/components/UserProfile.static.tsx
@@ -18,7 +18,7 @@ export default function UserProfile() {
           fill="#404565"
         />
       </svg>
-      <p className="kern-body kern-body--muted">{`${labels.LOGGED_IN_AS_LABEL}: ${userName}`}</p>
+      <p className="kern-body kern-body--muted">{`${labels.LOGGED_IN_AS_LABEL} ${userName}`}</p>
     </div>
   );
 }

--- a/app/components/VerfahrenTile.tsx
+++ b/app/components/VerfahrenTile.tsx
@@ -1,5 +1,6 @@
 import { clsx } from "clsx";
 import { Link } from "react-router";
+import { useTranslations } from "~/services/translations/context";
 
 export type VerfahrenTileProps = {
   readonly id: string;
@@ -52,6 +53,7 @@ export default function VerfahrenTile({
   geschaeftszeichen,
   // END
 }: VerfahrenTileProps) {
+  const { buttons } = useTranslations();
   const cssClasses = clsx(
     "relative",
     "after:border-y-1 sm:after:border-x-1 sm:after:rounded-kern-default after:border-kern-layout-border",
@@ -116,7 +118,7 @@ export default function VerfahrenTile({
       <div className="mb-kern-space-large gap-kern-space-x-large flex flex-wrap">
         <Link to={`/verfahren/${id}`} className="kern-btn kern-btn--primary">
           <span className="kern-icon kern-icon--open-in-new" aria-hidden />
-          <span className="kern-label">Verfahrensdetails anzeigen</span>
+          <span className="kern-label">{buttons.SHOW_VERFAHREN_DETAILS}</span>
         </Link>
         {abgeschlossen && urteilsHref ? (
           <Link to={urteilsHref} className="kern-btn kern-btn--secondary">
@@ -124,7 +126,7 @@ export default function VerfahrenTile({
               className="kern-icon kern-icon--insert-drive-file"
               aria-hidden
             />
-            <span className="kern-label">Urteil anzeigen</span>
+            <span className="kern-label">{buttons.SHOW_URTEIL}</span>
           </Link>
         ) : (
           ""

--- a/app/components/WorkInProgressAlert.static.tsx
+++ b/app/components/WorkInProgressAlert.static.tsx
@@ -1,4 +1,7 @@
+import { useTranslations } from "~/services/translations/context";
+
 export default function WorkInProgressAlert() {
+  const { alerts } = useTranslations();
   return (
     <div
       className="kern-alert kern-alert--warning my-kern-space-default"
@@ -9,13 +12,10 @@ export default function WorkInProgressAlert() {
           className="kern-icon kern-icon--warning kern-icon--small"
           aria-hidden
         ></span>
-        <span className="kern-title">Work in progress</span>
+        <span className="kern-title">{alerts.WORK_IN_PROGRESS_TITLE}</span>
       </div>
       <div className="kern-alert__body">
-        <p className="kern-body">
-          Diese Seite ist noch in der Entwicklung. Darstellungen und Layouts
-          können sich jederzeit ändern.
-        </p>
+        <p className="kern-body">{alerts.WORK_IN_PROGRESS_MESSAGE}</p>
       </div>
     </div>
   );

--- a/app/components/__test__/Header.test.tsx
+++ b/app/components/__test__/Header.test.tsx
@@ -3,9 +3,9 @@
 import { beforeEach, it, vi } from "vitest";
 import Header from "~/components/Header";
 import {
-  getTranslationsForTests,
-  renderWithTranslations,
-} from "~/util/test/testUtils";
+  getTestTranslations,
+  renderWithTestTranslations,
+} from "~/util/testUtils";
 
 vi.mock("react-router", async () => {
   const actual =
@@ -20,10 +20,10 @@ vi.mock("react-router", async () => {
 
 describe("Header", () => {
   let container: HTMLElement;
-  const { labels } = getTranslationsForTests();
+  const { labels } = getTestTranslations();
   describe("when user is not logged in", () => {
     beforeEach(() => {
-      ({ container } = renderWithTranslations(
+      ({ container } = renderWithTestTranslations(
         <Header userIsLoggedIn={false} />,
       ));
     });
@@ -46,7 +46,7 @@ describe("Header", () => {
 
   describe("when user is logged in", () => {
     beforeEach(() => {
-      ({ container } = renderWithTranslations(
+      ({ container } = renderWithTestTranslations(
         <Header userIsLoggedIn={true} />,
       ));
     });

--- a/app/components/__test__/Header.test.tsx
+++ b/app/components/__test__/Header.test.tsx
@@ -1,8 +1,11 @@
 // @vitest-environment jsdom
 
-import { render } from "@testing-library/react";
 import { beforeEach, it, vi } from "vitest";
 import Header from "~/components/Header";
+import {
+  getTranslationsForTests,
+  renderWithTranslations,
+} from "~/util/test/testUtils";
 
 vi.mock("react-router", async () => {
   const actual =
@@ -17,10 +20,12 @@ vi.mock("react-router", async () => {
 
 describe("Header", () => {
   let container: HTMLElement;
-
+  const { labels } = getTranslationsForTests();
   describe("when user is not logged in", () => {
     beforeEach(() => {
-      ({ container } = render(<Header userIsLoggedIn={false} />));
+      ({ container } = renderWithTranslations(
+        <Header userIsLoggedIn={false} />,
+      ));
     });
     it("should render <header>", () => {
       expect(container.querySelector("header")).toBeInTheDocument();
@@ -29,7 +34,7 @@ describe("Header", () => {
       expect(container.querySelector(".kern-kopfzeile")).toBeInTheDocument();
     });
     it("should not render UserProfile, Logo and Navigation", () => {
-      expect(container).not.toHaveTextContent("Angemeldet als:");
+      expect(container).not.toHaveTextContent(labels.LOGGED_IN_AS_LABEL);
       expect(
         container.querySelector(".kern-icon--network_node"),
       ).not.toBeInTheDocument();
@@ -41,7 +46,9 @@ describe("Header", () => {
 
   describe("when user is logged in", () => {
     beforeEach(() => {
-      ({ container } = render(<Header userIsLoggedIn={true} />));
+      ({ container } = renderWithTranslations(
+        <Header userIsLoggedIn={true} />,
+      ));
     });
 
     it("should render <header>", () => {
@@ -53,7 +60,7 @@ describe("Header", () => {
     });
 
     it("should render UserProfile, Logo and Navigation", () => {
-      expect(container).toHaveTextContent("Angemeldet als:");
+      expect(container).toHaveTextContent(labels.LOGGED_IN_AS_LABEL);
       expect(
         container.querySelector(".kern-icon--network_node"),
       ).toBeInTheDocument();

--- a/app/components/__test__/PageFooter.test.tsx
+++ b/app/components/__test__/PageFooter.test.tsx
@@ -1,29 +1,31 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { it } from "vitest";
+import {
+  getTranslationsForTests,
+  renderWithTranslations,
+} from "~/util/test/testUtils";
 import PageFooter from "../PageFooter";
 
 describe("PageFooter", () => {
+  const { labels, descriptions, contentLinkLabels } = getTranslationsForTests();
   it("should render a <nav/> with links and a project info", () => {
-    const { getByLabelText, getByRole } = render(
+    const { getByLabelText, getByRole } = renderWithTranslations(
       <MemoryRouter>
         <PageFooter />
       </MemoryRouter>,
     );
-
     // check if nav is being rendered
-    expect(
-      getByLabelText("Rechtliche und weiterführende Informationen"),
-    ).toBeInTheDocument();
+    expect(getByLabelText(labels.FOOTER_ARIA_LABEL)).toBeInTheDocument();
     // check if a link is being rendered
-    expect(getByRole("link", { name: "Datenschutz" })).toBeInTheDocument();
+    expect(
+      getByRole("link", { name: contentLinkLabels.DATENSCHUTZ_LINK_LABEL }),
+    ).toBeInTheDocument();
     // check if proejct info is present
     expect(
-      screen.getByText(
-        "Ein Onlineprojekt der DigitalService GmbH des Bundes in Zusammenarbeit mit der BRAK, SINC und im Auftrag des BMJV.",
-      ),
+      screen.getByText(descriptions.PROJECT_DESCRIPTION),
     ).toBeInTheDocument();
   });
 });

--- a/app/components/__test__/PageFooter.test.tsx
+++ b/app/components/__test__/PageFooter.test.tsx
@@ -3,10 +3,7 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { it } from "vitest";
-import PageFooter, {
-  FOOTER_ARIA_LABEL,
-  PROJECT_DESCRIPTION,
-} from "../PageFooter";
+import PageFooter from "../PageFooter";
 
 describe("PageFooter", () => {
   it("should render a <nav/> with links and a project info", () => {
@@ -17,10 +14,16 @@ describe("PageFooter", () => {
     );
 
     // check if nav is being rendered
-    expect(getByLabelText(FOOTER_ARIA_LABEL)).toBeInTheDocument();
+    expect(
+      getByLabelText("Rechtliche und weiterführende Informationen"),
+    ).toBeInTheDocument();
     // check if a link is being rendered
     expect(getByRole("link", { name: "Datenschutz" })).toBeInTheDocument();
     // check if proejct info is present
-    expect(screen.getByText(PROJECT_DESCRIPTION)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Ein Onlineprojekt der DigitalService GmbH des Bundes in Zusammenarbeit mit der BRAK, SINC und im Auftrag des BMJV.",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/app/components/__test__/PageFooter.test.tsx
+++ b/app/components/__test__/PageFooter.test.tsx
@@ -4,15 +4,15 @@ import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { it } from "vitest";
 import {
-  getTranslationsForTests,
-  renderWithTranslations,
-} from "~/util/test/testUtils";
+  getTestTranslations,
+  renderWithTestTranslations,
+} from "~/util/testUtils";
 import PageFooter from "../PageFooter";
 
 describe("PageFooter", () => {
-  const { labels, descriptions, contentLinkLabels } = getTranslationsForTests();
+  const { labels, descriptions, contentLinkLabels } = getTestTranslations();
   it("should render a <nav/> with links and a project info", () => {
-    const { getByLabelText, getByRole } = renderWithTranslations(
+    const { getByLabelText, getByRole } = renderWithTestTranslations(
       <MemoryRouter>
         <PageFooter />
       </MemoryRouter>,

--- a/app/components/__test__/VerfahrenTile.test.tsx
+++ b/app/components/__test__/VerfahrenTile.test.tsx
@@ -3,22 +3,28 @@
 import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { it } from "vitest";
+import {
+  getTranslationsForTests,
+  renderWithTranslations,
+} from "~/util/test/testUtils";
 import VerfahrenTile from "../VerfahrenTile";
 
 describe("VerfahrenTile", () => {
+  const { buttons } = getTranslationsForTests();
   it("should render the default state", () => {
-    const { getByRole, queryByRole, getByText, container } = render(
-      <MemoryRouter>
-        <VerfahrenTile id="123" mandantin="Klaus" />
-      </MemoryRouter>,
-    );
+    const { getByRole, queryByRole, getByText, container } =
+      renderWithTranslations(
+        <MemoryRouter>
+          <VerfahrenTile id="123" mandantin="Klaus" />
+        </MemoryRouter>,
+      );
 
     expect(getByText("Klaus")).toBeInTheDocument();
 
     expect(
       (
         getByRole("link", {
-          name: "Verfahrensdetails anzeigen",
+          name: buttons.SHOW_VERFAHREN_DETAILS,
         }) as HTMLAnchorElement
       ).href,
     ).toContain("/verfahren/123");
@@ -26,7 +32,7 @@ describe("VerfahrenTile", () => {
     // no "Urteil anzeigen" button
     expect(
       queryByRole("link", {
-        name: "Urteil anzeigen",
+        name: buttons.SHOW_URTEIL,
       }),
     ).not.toBeInTheDocument();
 

--- a/app/components/__test__/VerfahrenTile.test.tsx
+++ b/app/components/__test__/VerfahrenTile.test.tsx
@@ -4,16 +4,16 @@ import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { it } from "vitest";
 import {
-  getTranslationsForTests,
-  renderWithTranslations,
-} from "~/util/test/testUtils";
+  getTestTranslations,
+  renderWithTestTranslations,
+} from "~/util/testUtils";
 import VerfahrenTile from "../VerfahrenTile";
 
 describe("VerfahrenTile", () => {
-  const { buttons } = getTranslationsForTests();
+  const { buttons } = getTestTranslations();
   it("should render the default state", () => {
     const { getByRole, queryByRole, getByText, container } =
-      renderWithTranslations(
+      renderWithTestTranslations(
         <MemoryRouter>
           <VerfahrenTile id="123" mandantin="Klaus" />
         </MemoryRouter>,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -18,6 +18,8 @@ import {
 import { Breadcrumbs } from "~/components/Breadcrumbs";
 import Header from "~/components/Header";
 import { useNonce } from "~/services/security/nonce";
+import { dictionaries } from "~/services/translations";
+import { TranslationsContext } from "~/services/translations/context";
 import type { Route } from "./+types/root";
 import { LogoutInactiveUserWrapper } from "./components/LogoutInactiveUserWrapper";
 import { config } from "./config/config";
@@ -90,10 +92,13 @@ export default function App() {
   const { userIsLoggedIn } = useLoaderData<RootLoader>();
 
   return (
-    <LogoutInactiveUserWrapper handleInactivity={userIsLoggedIn}>
-      <Breadcrumbs />
-      <Outlet />
-    </LogoutInactiveUserWrapper>
+    // we currently only support German, so we hardcode the dictionary here, but in the future we cab make this dynamic and correct language from the backend
+    <TranslationsContext.Provider value={dictionaries.de}>
+      <LogoutInactiveUserWrapper handleInactivity={userIsLoggedIn}>
+        <Breadcrumbs />
+        <Outlet />
+      </LogoutInactiveUserWrapper>
+    </TranslationsContext.Provider>
   );
 }
 

--- a/app/routes/barrierefreiheit.tsx
+++ b/app/routes/barrierefreiheit.tsx
@@ -1,5 +1,7 @@
 import ContentPage from "~/components/ContentPage";
+import { useTranslations } from "~/services/translations/context";
 
 export default function BarrierefreiheitPage() {
-  return <ContentPage title="Erklärung zur Barrierefreiheit">...</ContentPage>;
+  const { titles } = useTranslations();
+  return <ContentPage title={titles.BARRIEREFREIHEIT_TITLE}>...</ContentPage>;
 }

--- a/app/routes/datenschutz.tsx
+++ b/app/routes/datenschutz.tsx
@@ -1,7 +1,7 @@
 import ContentPage from "~/components/ContentPage";
+import { useTranslations } from "~/services/translations/context";
 
 export default function DatenschutzPage() {
-  return (
-    <ContentPage title="Datenschutzerklärung zur Webseite">...</ContentPage>
-  );
+  const { titles } = useTranslations();
+  return <ContentPage title={titles.DATENSCHUTZ_TITLE}>...</ContentPage>;
 }

--- a/app/routes/error.tsx
+++ b/app/routes/error.tsx
@@ -1,13 +1,15 @@
 import { Link } from "react-router";
+import { useTranslations } from "~/services/translations/context";
 
 export default function ErrorPage() {
+  const { labels, errorMessages } = useTranslations();
   return (
     <main>
       <h1 className="kern-heading-display">
-        Bitte versuchen Sie es später erneut.
+        {errorMessages.TRY_LATER_MESSAGE}
       </h1>
       <Link to="/" className="kern-btn kern-btn--primary">
-        <span className="kern-label">Startseite</span>
+        <span className="kern-label">{labels.START_PAGE_LABEL}</span>
       </Link>
     </main>
   );

--- a/app/routes/hilfe-und-kontakt.tsx
+++ b/app/routes/hilfe-und-kontakt.tsx
@@ -1,5 +1,7 @@
 import ContentPage from "~/components/ContentPage";
+import { useTranslations } from "~/services/translations/context";
 
 export default function HilfeUndKontaktPage() {
-  return <ContentPage title="Hilfe und Kontakt">...</ContentPage>;
+  const { titles } = useTranslations();
+  return <ContentPage title={titles.HILFE_UND_KONTAKT_TITLE}>...</ContentPage>;
 }

--- a/app/routes/impressum.tsx
+++ b/app/routes/impressum.tsx
@@ -1,5 +1,7 @@
 import ContentPage from "~/components/ContentPage";
+import { useTranslations } from "~/services/translations/context";
 
 export default function ImpressumPage() {
-  return <ContentPage title="Impressum">...</ContentPage>;
+  const { titles } = useTranslations();
+  return <ContentPage title={titles.IMPRESSUM_TITLE}>...</ContentPage>;
 }

--- a/app/routes/login/_index.tsx
+++ b/app/routes/login/_index.tsx
@@ -9,6 +9,7 @@ import Logo from "~/components/Logo.static";
 import { PageMetadata } from "~/components/PageMetadata";
 import { config } from "~/config/config";
 import { getUserSession } from "~/services/prototype.session.server";
+import { de } from "~/services/translations/de";
 import { LoginError, LoginType } from "../action.login-user";
 import { LogoutType } from "../action.logout-user";
 
@@ -39,6 +40,7 @@ export default function LoginPage() {
   const alertStatus = searchParams.get("status") as AlertState;
   const isDevelopment = environment === "development";
   const currentLoginType = isDevelopment ? LoginType.Developer : LoginType.BeA;
+  const { alert } = de;
 
   return (
     <>
@@ -57,10 +59,7 @@ export default function LoginPage() {
             <span className="kern-title">Automatisch abgemeldet</span>
           </div>
           <div className="kern-alert__body">
-            <p className="kern-body">
-              Aus Sicherheitsgründen wurden Sie nach 60 Minuten Inaktivität
-              automatisch abgemeldet. Bitte melden Sie sich erneut an.
-            </p>
+            <p className="kern-body">{alert.LOGOUT_AUTOMATIC_MESSAGE}</p>
           </div>
         </div>
       )}
@@ -75,7 +74,7 @@ export default function LoginPage() {
               className="kern-icon kern-icon--success kern-icon--small"
               aria-hidden
             ></span>
-            <span className="kern-title">Erfolgreich abgemeldet</span>
+            <span className="kern-title">{alert.LOGOUT_BY_USER_MESSAGE}</span>
           </div>
         </div>
       )}

--- a/app/routes/login/_index.tsx
+++ b/app/routes/login/_index.tsx
@@ -9,7 +9,7 @@ import Logo from "~/components/Logo.static";
 import { PageMetadata } from "~/components/PageMetadata";
 import { config } from "~/config/config";
 import { getUserSession } from "~/services/prototype.session.server";
-import { de } from "~/services/translations/de";
+import { useTranslations } from "~/services/translations/context";
 import { LoginError, LoginType } from "../action.login-user";
 import { LogoutType } from "../action.logout-user";
 
@@ -29,23 +29,22 @@ export async function loader({ request }: { request: Request }) {
   return { environment };
 }
 
-const loginButtonLabels: Record<LoginType, string> = {
-  [LoginType.BeA]: "Anmeldung Anwaltschaft (über beA Login)",
-  [LoginType.Developer]: "Login as Developer",
-};
-
 export default function LoginPage() {
   const [searchParams] = useSearchParams();
   const { environment } = useLoaderData<typeof loader>();
   const alertStatus = searchParams.get("status") as AlertState;
   const isDevelopment = environment === "development";
   const currentLoginType = isDevelopment ? LoginType.Developer : LoginType.BeA;
-  const { alert } = de;
+  const { alerts, buttons, titles } = useTranslations();
+
+  const loginButtonLabels: Record<LoginType, string> = {
+    [LoginType.BeA]: buttons.LOGIN_BUTTON_BEA,
+    [LoginType.Developer]: buttons.LOGIN_BUTTON_DEVELOPER,
+  };
 
   return (
     <>
       <PageMetadata />
-
       {alertStatus === LogoutType.Automatic && (
         <div
           className="kern-alert kern-alert--warning my-kern-space-default"
@@ -56,10 +55,10 @@ export default function LoginPage() {
               className="kern-icon kern-icon--warning kern-icon--small"
               aria-hidden
             ></span>
-            <span className="kern-title">Automatisch abgemeldet</span>
+            <span className="kern-title">{alerts.LOGOUT_AUTOMATIC_TITLE}</span>
           </div>
           <div className="kern-alert__body">
-            <p className="kern-body">{alert.LOGOUT_AUTOMATIC_MESSAGE}</p>
+            <p className="kern-body">{alerts.LOGOUT_AUTOMATIC_MESSAGE}</p>
           </div>
         </div>
       )}
@@ -74,7 +73,7 @@ export default function LoginPage() {
               className="kern-icon kern-icon--success kern-icon--small"
               aria-hidden
             ></span>
-            <span className="kern-title">{alert.LOGOUT_BY_USER_MESSAGE}</span>
+            <span className="kern-title">{alerts.LOGOUT_BY_USER_MESSAGE}</span>
           </div>
         </div>
       )}
@@ -92,10 +91,7 @@ export default function LoginPage() {
             <span className="kern-title">Fehler bei der Anmeldung</span>
           </div>
           <div className="kern-alert__body">
-            <p className="kern-body">
-              Die Anmeldung über beA-Zugangsdaten war nicht erfolgreich. Bitte
-              versuchen Sie es erneut.
-            </p>
+            <p className="kern-body">{alerts.LOGIN_ERROR_MESSAGE_BEA}</p>
           </div>
         </div>
       )}
@@ -107,8 +103,7 @@ export default function LoginPage() {
           <hr className="kern-divider mt-kern-space-default" aria-hidden />
 
           <p className="kern-subline my-kern-space-default">
-            Willkommen auf der Pilotplattform für den digitalen Austausch
-            zwischen Gerichten und Verfahrensbeteiligten.
+            {titles.WELCOME_TITLE}
           </p>
 
           <Form method="post" action="/action/login-user">
@@ -127,7 +122,9 @@ export default function LoginPage() {
                 className="kern-btn kern-btn--primary kern-btn--block"
                 disabled
               >
-                <span className="kern-label">Anmeldung Gerichte</span>
+                <span className="kern-label">
+                  {buttons.LOGIN_BUTTON_GERICHTE}
+                </span>
               </button>
 
               {/* only render "Testzugang" demo link for non production environments */}
@@ -140,7 +137,9 @@ export default function LoginPage() {
                   }}
                   data-testid="demo-button"
                 >
-                  <span className="kern-label">Testzugang</span>
+                  <span className="kern-label">
+                    {buttons.LOGIN_BUTTON_TEST_ZUGANG}
+                  </span>
                 </Link>
               )}
             </div>

--- a/app/routes/open-source.tsx
+++ b/app/routes/open-source.tsx
@@ -1,5 +1,7 @@
 import ContentPage from "~/components/ContentPage";
+import { useTranslations } from "~/services/translations/context";
 
 export default function OpenSourcePage() {
-  return <ContentPage title="Open Source Code">...</ContentPage>;
+  const { titles } = useTranslations();
+  return <ContentPage title={titles.OPEN_SOURCE_CODE_TITLE}>...</ContentPage>;
 }

--- a/app/routes/weitere-informationen.tsx
+++ b/app/routes/weitere-informationen.tsx
@@ -1,5 +1,9 @@
 import ContentPage from "~/components/ContentPage";
+import { useTranslations } from "~/services/translations/context";
 
 export default function WeitereInformationenPage() {
-  return <ContentPage title="Weitere Informationen">...</ContentPage>;
+  const { titles } = useTranslations();
+  return (
+    <ContentPage title={titles.WEITERE_INFORMATIONEN_TITLE}>...</ContentPage>
+  );
 }

--- a/app/services/translations/__test__/context.test.tsx
+++ b/app/services/translations/__test__/context.test.tsx
@@ -13,6 +13,16 @@ describe("useTranslations", () => {
     expect(result.current).toEqual(dictionaries.de);
   });
 
+  it("returns EN translations when provided", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TranslationsProvider value={dictionaries.en}>
+        {children}
+      </TranslationsProvider>
+    );
+    const { result } = renderHook(() => useTranslations(), { wrapper });
+    expect(result.current).toEqual(dictionaries.en);
+  });
+
   it("updates when provider value changes", () => {
     const custom1 = {
       ...dictionaries.de,

--- a/app/services/translations/__test__/context.test.tsx
+++ b/app/services/translations/__test__/context.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import React, { useState } from "react";
+import { dictionaries } from "~/services/translations";
+import { TranslationsProvider, useTranslations } from "../context";
+
+describe("useTranslations", () => {
+  it("returns default DE translations when no value is provided", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TranslationsProvider value={undefined}>{children}</TranslationsProvider>
+    );
+    const { result } = renderHook(() => useTranslations(), { wrapper });
+    expect(result.current).toEqual(dictionaries.de);
+  });
+
+  it("updates when provider value changes", () => {
+    const custom1 = {
+      ...dictionaries.de,
+      labels: { ...dictionaries.de.labels, A: "A1" },
+    };
+    const custom2 = {
+      ...dictionaries.de,
+      labels: { ...dictionaries.de.labels, A: "A2" },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const setValueRef = { current: (_: typeof custom1) => {} };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => {
+      const [value, setValue] = useState(custom1);
+      setValueRef.current = setValue;
+      return (
+        <TranslationsProvider value={value}>{children}</TranslationsProvider>
+      );
+    };
+
+    const { result, rerender } = renderHook(() => useTranslations(), {
+      wrapper,
+    });
+    expect(result.current).toEqual(custom1);
+
+    act(() => {
+      setValueRef.current(custom2);
+    });
+    rerender();
+    expect(result.current).toEqual(custom2);
+  });
+
+  it("returns default value when used without provider", () => {
+    const { result } = renderHook(() => useTranslations());
+    expect(result.current).toEqual(dictionaries.de);
+  });
+});

--- a/app/services/translations/context.tsx
+++ b/app/services/translations/context.tsx
@@ -1,0 +1,23 @@
+import React, { useContext } from "react";
+import { dictionaries, Translations } from "~/services/translations/index";
+
+export const TranslationsContext = React.createContext<Translations>(
+  dictionaries.de,
+);
+
+export function TranslationsProvider({
+  children,
+  value = dictionaries.de,
+}: {
+  children: React.ReactNode;
+  value?: Translations;
+}) {
+  return (
+    <TranslationsContext.Provider value={value}>
+      {children}
+    </TranslationsContext.Provider>
+  );
+}
+export function useTranslations() {
+  return useContext(TranslationsContext);
+}

--- a/app/services/translations/de.ts
+++ b/app/services/translations/de.ts
@@ -12,6 +12,7 @@ export const de = {
   },
   errorMessages: {
     TRY_LATER_MESSAGE: "Bitte versuchen Sie es später erneut.",
+    LOGIN_ERROR_MESSAGE: "Fehler bei der Anmeldung",
   },
   alerts: {
     LOGOUT_AUTOMATIC_TITLE: "Automatisch abgemeldet",

--- a/app/services/translations/de.ts
+++ b/app/services/translations/de.ts
@@ -50,7 +50,7 @@ export const de = {
   },
   descriptions: {
     PROJECT_DESCRIPTION:
-      " Ein Onlineprojekt der DigitalService GmbH des Bundes in Zusammenarbeit mit der BRAK, SINC und im Auftrag des BMJV.",
+      "Ein Onlineprojekt der DigitalService GmbH des Bundes in Zusammenarbeit mit der BRAK, SINC und im Auftrag des BMJV.",
     PLATFORM_DESCRIPTION:
       "Willkommen auf der Pilotplattform für den digitalen Austausch zwischen Gerichten und Verfahrensbeteiligten.",
   },

--- a/app/services/translations/de.ts
+++ b/app/services/translations/de.ts
@@ -7,7 +7,11 @@ export const de = {
     LOGIN_BUTTON_GERICHTE: "Anmeldung Gerichte",
     LOGIN_BUTTON_TEST_ZUGANG: "Testzugang",
     ABMELDEN_BUTTON: "Abmelden",
-    SHOW_VERFAHERN_DETAILS: "Verfahrensdetails anzeigen",
+    SHOW_VERFAHREN_DETAILS: "Verfahrensdetails anzeigen",
+    SHOW_URTEIL: "Urteil anzeigen",
+  },
+  errorMessages: {
+    TRY_LATER_MESSAGE: "Bitte versuchen Sie es später erneut.",
   },
   alerts: {
     LOGOUT_AUTOMATIC_TITLE: "Automatisch abgemeldet",
@@ -28,17 +32,35 @@ export const de = {
     KALENDER_LABEL: "Kalender",
     VERFAHREN_DETAILS_LABEL: "Verfahrensdetails",
     DATEIANSICHT_LABEL: "Dateiansicht",
+    KOPFZEILE_LABEL: "Offizielle Website – Bundesrepublik Deutschland",
+    LOGO_LABEL: "Kommunikationsplattform",
+    LOGGED_IN_AS_LABEL: "Angemeldet als",
+    START_PAGE_LABEL: "Startseite",
   },
   titles: {
     PLATFORM_TITLE: "Kommunikationsplattform | Justiz-Services",
     WELCOME_TITLE:
       "Willkommen auf der Pilotplattform für den digitalen Austausch zwischen Gerichten und Verfahrensbeteiligten.",
+    DATENSCHUTZ_TITLE: "Datenschutzerklärung zur Webseite",
+    WEITERE_INFORMATIONEN_TITLE: "Weitere Informationen",
+    BARRIEREFREIHEIT_TITLE: "Erklärung zur Barrierefreiheit",
+    HILFE_UND_KONTAKT_TITLE: "Hilfe und Kontakt",
+    OPEN_SOURCE_CODE_TITLE: "Open Source Code",
+    IMPRESSUM_TITLE: "Impressum",
   },
   descriptions: {
     PROJECT_DESCRIPTION:
       " Ein Onlineprojekt der DigitalService GmbH des Bundes in Zusammenarbeit mit der BRAK, SINC und im Auftrag des BMJV.",
     PLATFORM_DESCRIPTION:
       "Willkommen auf der Pilotplattform für den digitalen Austausch zwischen Gerichten und Verfahrensbeteiligten.",
+  },
+  contentLinkLabels: {
+    DATENSCHUTZ_LINK_LABEL: "Datenschutz",
+    WEITERE_INFORMATIONEN_LINK_LABEL: "Weitere Informationen",
+    BARRIEREFREIHEIT_LINK_LABEL: "Barrierefreiheit",
+    HILFE_UND_KONTAKT_LINK_LABEL: "Hilfe und Kontakt",
+    OPEN_SOURCE_CODE_LINK_LABEL: "Open Source Code",
+    IMPRESSUM_LINK_LABEL: "Impressum",
   },
 } as const;
 

--- a/app/services/translations/de.ts
+++ b/app/services/translations/de.ts
@@ -1,0 +1,26 @@
+// German translations
+
+export const de = {
+  footer: {
+    PROJECT_DESCRIPTION:
+      " Ein Onlineprojekt der DigitalService GmbH des Bundes in Zusammenarbeit mit der BRAK, SINC und im Auftrag des BMJV.",
+    FOOTER_ARIA_LABEL: "Rechtliche und weiterführende Informationen",
+  },
+  login: {
+    LOGIN_BUTTON_BEA: "Anmeldung Anwaltschaft (über beA Login)",
+    LOGIN_BUTTON_DEVELOPER: "Login als Entwickler*in",
+    LOGIN_BUTTON_GERICHTE: "Anmeldung Gerichte",
+    LOGIN_BUTTON_TEST_ZUGANG: "Testzugang",
+    WELCOME_TITLE:
+      "Willkommen auf der Pilotplattform für den digitalen Austausch zwischen Gerichten und Verfahrensbeteiligten.",
+  },
+  alert: {
+    LOGOUT_AUTOMATIC_MESSAGE:
+      "Aus Sicherheitsgründen wurden Sie nach 60 Minuten Inaktivität automatisch abgemeldet. Bitte melden Sie sich erneut an.",
+    LOGOUT_BY_USER_MESSAGE: "Erfolgreich abgemeldet",
+    LOGIN_ERROR_MESSAGE_BEA:
+      "Die Anmeldung über beA ist fehlgeschlagen. Bitte versuchen Sie es erneut.",
+  },
+} as const;
+
+export type RouteName = keyof typeof de;

--- a/app/services/translations/de.ts
+++ b/app/services/translations/de.ts
@@ -34,7 +34,7 @@ export const de = {
     DATEIANSICHT_LABEL: "Dateiansicht",
     KOPFZEILE_LABEL: "Offizielle Website – Bundesrepublik Deutschland",
     LOGO_LABEL: "Kommunikationsplattform",
-    LOGGED_IN_AS_LABEL: "Angemeldet als",
+    LOGGED_IN_AS_LABEL: "Angemeldet als:",
     START_PAGE_LABEL: "Startseite",
   },
   titles: {

--- a/app/services/translations/de.ts
+++ b/app/services/translations/de.ts
@@ -1,26 +1,45 @@
 // German translations
 
 export const de = {
-  footer: {
-    PROJECT_DESCRIPTION:
-      " Ein Onlineprojekt der DigitalService GmbH des Bundes in Zusammenarbeit mit der BRAK, SINC und im Auftrag des BMJV.",
-    FOOTER_ARIA_LABEL: "Rechtliche und weiterführende Informationen",
-  },
-  login: {
+  buttons: {
     LOGIN_BUTTON_BEA: "Anmeldung Anwaltschaft (über beA Login)",
     LOGIN_BUTTON_DEVELOPER: "Login als Entwickler*in",
     LOGIN_BUTTON_GERICHTE: "Anmeldung Gerichte",
     LOGIN_BUTTON_TEST_ZUGANG: "Testzugang",
-    WELCOME_TITLE:
-      "Willkommen auf der Pilotplattform für den digitalen Austausch zwischen Gerichten und Verfahrensbeteiligten.",
+    ABMELDEN_BUTTON: "Abmelden",
+    SHOW_VERFAHERN_DETAILS: "Verfahrensdetails anzeigen",
   },
-  alert: {
+  alerts: {
+    LOGOUT_AUTOMATIC_TITLE: "Automatisch abgemeldet",
     LOGOUT_AUTOMATIC_MESSAGE:
       "Aus Sicherheitsgründen wurden Sie nach 60 Minuten Inaktivität automatisch abgemeldet. Bitte melden Sie sich erneut an.",
     LOGOUT_BY_USER_MESSAGE: "Erfolgreich abgemeldet",
     LOGIN_ERROR_MESSAGE_BEA:
       "Die Anmeldung über beA ist fehlgeschlagen. Bitte versuchen Sie es erneut.",
+    WORK_IN_PROGRESS_TITLE: "Work in progress",
+    WORK_IN_PROGRESS_MESSAGE:
+      "Diese Seite ist noch in der Entwicklung. Darstellungen und Layouts können sich jederzeit ändern.",
+  },
+  labels: {
+    FOOTER_ARIA_LABEL: "Rechtliche und weiterführende Informationen",
+    UEBERSICHT_LABEL: "Übersicht",
+    VERFAHREN_LABEL: "Verfahren",
+    MITTEILUNGEN_LABEL: "Mitteilungen",
+    KALENDER_LABEL: "Kalender",
+    VERFAHREN_DETAILS_LABEL: "Verfahrensdetails",
+    DATEIANSICHT_LABEL: "Dateiansicht",
+  },
+  titles: {
+    PLATFORM_TITLE: "Kommunikationsplattform | Justiz-Services",
+    WELCOME_TITLE:
+      "Willkommen auf der Pilotplattform für den digitalen Austausch zwischen Gerichten und Verfahrensbeteiligten.",
+  },
+  descriptions: {
+    PROJECT_DESCRIPTION:
+      " Ein Onlineprojekt der DigitalService GmbH des Bundes in Zusammenarbeit mit der BRAK, SINC und im Auftrag des BMJV.",
+    PLATFORM_DESCRIPTION:
+      "Willkommen auf der Pilotplattform für den digitalen Austausch zwischen Gerichten und Verfahrensbeteiligten.",
   },
 } as const;
 
-export type RouteName = keyof typeof de;
+export default de;

--- a/app/services/translations/en.ts
+++ b/app/services/translations/en.ts
@@ -14,6 +14,7 @@ export const en: Translations = {
   },
   errorMessages: {
     TRY_LATER_MESSAGE: "Please try again later.",
+    LOGIN_ERROR_MESSAGE: "Login error",
   },
   alerts: {
     LOGOUT_AUTOMATIC_TITLE: "Automatically logged out",
@@ -36,7 +37,6 @@ export const en: Translations = {
     KOPFZEILE_LABEL: "Official website – Federal Republic of Germany",
     LOGO_LABEL: "Kommunikationsplattform",
     LOGGED_IN_AS_LABEL: "Logged in as:",
-
     START_PAGE_LABEL: "Home",
   },
   titles: {

--- a/app/services/translations/en.ts
+++ b/app/services/translations/en.ts
@@ -52,7 +52,7 @@ export const en: Translations = {
   },
   descriptions: {
     PROJECT_DESCRIPTION:
-      " An online project by DigitalService GmbH of the Federal Government in cooperation with BRAK, SINC and on behalf of the BMJV.",
+      "An online project by DigitalService GmbH of the Federal Government in cooperation with BRAK, SINC and on behalf of the BMJV.",
     PLATFORM_DESCRIPTION:
       "Welcome to the pilot platform for digital exchange between courts and parties involved in proceedings.",
   },

--- a/app/services/translations/en.ts
+++ b/app/services/translations/en.ts
@@ -35,7 +35,7 @@ export const en: Translations = {
     DATEIANSICHT_LABEL: "File view",
     KOPFZEILE_LABEL: "Official website – Federal Republic of Germany",
     LOGO_LABEL: "Kommunikationsplattform",
-    LOGGED_IN_AS_LABEL: "Logged in as",
+    LOGGED_IN_AS_LABEL: "Logged in as:",
 
     START_PAGE_LABEL: "Home",
   },

--- a/app/services/translations/en.ts
+++ b/app/services/translations/en.ts
@@ -9,7 +9,11 @@ export const en: Translations = {
     LOGIN_BUTTON_GERICHTE: "Login for courts",
     LOGIN_BUTTON_TEST_ZUGANG: "Test access",
     ABMELDEN_BUTTON: "Logout",
-    SHOW_VERFAHERN_DETAILS: "Show case details",
+    SHOW_VERFAHREN_DETAILS: "Show case details",
+    SHOW_URTEIL: "Show judgment",
+  },
+  errorMessages: {
+    TRY_LATER_MESSAGE: "Please try again later.",
   },
   alerts: {
     LOGOUT_AUTOMATIC_TITLE: "Automatically logged out",
@@ -29,17 +33,36 @@ export const en: Translations = {
     KALENDER_LABEL: "Calendar",
     VERFAHREN_DETAILS_LABEL: "Case details",
     DATEIANSICHT_LABEL: "File view",
+    KOPFZEILE_LABEL: "Official website – Federal Republic of Germany",
+    LOGO_LABEL: "Kommunikationsplattform",
+    LOGGED_IN_AS_LABEL: "Logged in as",
+
+    START_PAGE_LABEL: "Home",
   },
   titles: {
     PLATFORM_TITLE: "Communication Platform | Justice Services",
     WELCOME_TITLE:
       "Welcome to the pilot platform for digital exchange between courts and parties involved in proceedings.",
+    DATENSCHUTZ_TITLE: "Privacy Policy for the Website",
+    WEITERE_INFORMATIONEN_TITLE: "Further Information",
+    BARRIEREFREIHEIT_TITLE: "Accessibility Statement",
+    HILFE_UND_KONTAKT_TITLE: "Help and Contact",
+    OPEN_SOURCE_CODE_TITLE: "Open Source Code",
+    IMPRESSUM_TITLE: "Imprint",
   },
   descriptions: {
     PROJECT_DESCRIPTION:
       " An online project by DigitalService GmbH of the Federal Government in cooperation with BRAK, SINC and on behalf of the BMJV.",
     PLATFORM_DESCRIPTION:
       "Welcome to the pilot platform for digital exchange between courts and parties involved in proceedings.",
+  },
+  contentLinkLabels: {
+    DATENSCHUTZ_LINK_LABEL: "Data protection",
+    WEITERE_INFORMATIONEN_LINK_LABEL: "Further information",
+    BARRIEREFREIHEIT_LINK_LABEL: "Accessibility",
+    HILFE_UND_KONTAKT_LINK_LABEL: "Help and contact",
+    OPEN_SOURCE_CODE_LINK_LABEL: "Open source code",
+    IMPRESSUM_LINK_LABEL: "Imprint",
   },
 } as const;
 

--- a/app/services/translations/en.ts
+++ b/app/services/translations/en.ts
@@ -1,0 +1,46 @@
+// English translations
+
+import { Translations } from "~/services/translations/index";
+
+export const en: Translations = {
+  buttons: {
+    LOGIN_BUTTON_BEA: "Login for lawyers (via beA Login)",
+    LOGIN_BUTTON_DEVELOPER: "Login as developer",
+    LOGIN_BUTTON_GERICHTE: "Login for courts",
+    LOGIN_BUTTON_TEST_ZUGANG: "Test access",
+    ABMELDEN_BUTTON: "Logout",
+    SHOW_VERFAHERN_DETAILS: "Show case details",
+  },
+  alerts: {
+    LOGOUT_AUTOMATIC_TITLE: "Automatically logged out",
+    LOGOUT_AUTOMATIC_MESSAGE:
+      "For security reasons, you have been automatically logged out after 60 minutes of inactivity. Please log in again.",
+    LOGOUT_BY_USER_MESSAGE: "Successfully logged out",
+    LOGIN_ERROR_MESSAGE_BEA: "Login via beA failed. Please try again.",
+    WORK_IN_PROGRESS_TITLE: "Work in progress",
+    WORK_IN_PROGRESS_MESSAGE:
+      "This page is still under development. Layouts and displays may change at any time.",
+  },
+  labels: {
+    FOOTER_ARIA_LABEL: "Legal and further information",
+    UEBERSICHT_LABEL: "Overview",
+    VERFAHREN_LABEL: "Cases",
+    MITTEILUNGEN_LABEL: "Messages",
+    KALENDER_LABEL: "Calendar",
+    VERFAHREN_DETAILS_LABEL: "Case details",
+    DATEIANSICHT_LABEL: "File view",
+  },
+  titles: {
+    PLATFORM_TITLE: "Communication Platform | Justice Services",
+    WELCOME_TITLE:
+      "Welcome to the pilot platform for digital exchange between courts and parties involved in proceedings.",
+  },
+  descriptions: {
+    PROJECT_DESCRIPTION:
+      " An online project by DigitalService GmbH of the Federal Government in cooperation with BRAK, SINC and on behalf of the BMJV.",
+    PLATFORM_DESCRIPTION:
+      "Welcome to the pilot platform for digital exchange between courts and parties involved in proceedings.",
+  },
+} as const;
+
+export default en;

--- a/app/services/translations/index.ts
+++ b/app/services/translations/index.ts
@@ -1,11 +1,11 @@
 import de from "./de";
 import en from "./en";
 
-const translations = { de, en } as const;
+export const dictionaries = { de, en } as const;
 
-export type Language = keyof typeof translations;
-export type RouteName = keyof typeof de;
-
-export function getTranslations(lang: Language) {
-  return translations[lang] || translations.de;
-}
+export type Language = keyof typeof dictionaries;
+//This converts all properties from DE translations to strings, hence making the type usable for type safety in other languages without enforcing the german text
+export type Stringified<T> = {
+  [K in keyof T]: T[K] extends object ? Stringified<T[K]> : string;
+};
+export type Translations = Stringified<typeof de>;

--- a/app/services/translations/index.ts
+++ b/app/services/translations/index.ts
@@ -1,0 +1,11 @@
+import de from "./de";
+import en from "./en";
+
+const translations = { de, en } as const;
+
+export type Language = keyof typeof translations;
+export type RouteName = keyof typeof de;
+
+export function getTranslations(lang: Language) {
+  return translations[lang] || translations.de;
+}

--- a/app/util/__test__/testUtils.test.tsx
+++ b/app/util/__test__/testUtils.test.tsx
@@ -1,0 +1,15 @@
+// @vitest-environment jsdom
+import { screen } from "@testing-library/react";
+
+import { useTranslations } from "~/services/translations/context";
+import { renderWithTestTranslations } from "~/util/testUtils";
+
+function TestComponent() {
+  const { labels } = useTranslations();
+  return <span>{labels.LOGGED_IN_AS_LABEL}</span>;
+}
+
+it("provides German translations context", () => {
+  renderWithTestTranslations(<TestComponent />);
+  expect(screen.getByText("Angemeldet als:")).toBeInTheDocument();
+});

--- a/app/util/test/testUtils.tsx
+++ b/app/util/test/testUtils.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { dictionaries, Language } from "~/services/translations";
+import { TranslationsProvider } from "~/services/translations/context";
+
+const TEST_LANGUAGE: Language = "de";
+
+export function getTranslationsForTests() {
+  // Returning DE translations for tests, but in the future we might want to make this configurable to work with other languages
+  return dictionaries[TEST_LANGUAGE];
+}
+
+/**
+ * Returns the translations object for tests.
+ * Currently returns German translations, but can be made configurable for other languages in the future.
+ */
+
+/**
+ * Renders a React element wrapped in the TranslationsProvider for testing.
+ * Uses the test language defined in DEFAULT_LANGUAGE.
+ */
+export function renderWithTranslations(ui: React.ReactElement) {
+  return render(
+    <TranslationsProvider value={getTranslationsForTests()}>
+      {ui}
+    </TranslationsProvider>,
+  );
+}

--- a/app/util/testUtils.tsx
+++ b/app/util/testUtils.tsx
@@ -5,7 +5,7 @@ import { TranslationsProvider } from "~/services/translations/context";
 
 const TEST_LANGUAGE: Language = "de";
 
-export function getTranslationsForTests() {
+export function getTestTranslations() {
   // Returning DE translations for tests, but in the future we might want to make this configurable to work with other languages
   return dictionaries[TEST_LANGUAGE];
 }
@@ -19,9 +19,9 @@ export function getTranslationsForTests() {
  * Renders a React element wrapped in the TranslationsProvider for testing.
  * Uses the test language defined in DEFAULT_LANGUAGE.
  */
-export function renderWithTranslations(ui: React.ReactElement) {
+export function renderWithTestTranslations(ui: React.ReactElement) {
   return render(
-    <TranslationsProvider value={getTranslationsForTests()}>
+    <TranslationsProvider value={getTestTranslations()}>
       {ui}
     </TranslationsProvider>,
   );

--- a/tests/e2e/demo-mode.spec.ts
+++ b/tests/e2e/demo-mode.spec.ts
@@ -1,12 +1,16 @@
 import { expect, test } from "@playwright/test";
+import { getTestTranslations } from "~/util/testUtils";
 
 test.describe("Demo mode (functionality)", () => {
+  const { buttons } = getTestTranslations();
   test(`Can be activated using the "Testzugang" button (on staging environment)`, async ({
     page,
   }) => {
     await page.goto("/");
     await page.getByTestId("demo-button").click();
-    await expect(page.getByRole("button", { name: "Abmelden" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: buttons.ABMELDEN_BUTTON }),
+    ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Neue Klage einreichen" }),
     ).toBeVisible();

--- a/tests/e2e/footer.spec.ts
+++ b/tests/e2e/footer.spec.ts
@@ -1,28 +1,39 @@
 import { expect, test } from "@playwright/test";
+import { getTestTranslations } from "~/util/testUtils";
+
+const { contentLinkLabels, titles } = getTestTranslations();
 
 const links = [
   {
-    label: "Datenschutz",
+    label: contentLinkLabels.DATENSCHUTZ_LINK_LABEL,
     url: "/datenschutz",
-    h1: "Datenschutzerklärung zur Webseite",
+    h1: titles.DATENSCHUTZ_TITLE,
   },
   {
-    label: "Weitere Informationen",
+    label: contentLinkLabels.WEITERE_INFORMATIONEN_LINK_LABEL,
     url: "/weitere-informationen",
-    h1: "Weitere Informationen",
+    h1: titles.WEITERE_INFORMATIONEN_TITLE,
   },
   {
-    label: "Barrierefreiheit",
+    label: contentLinkLabels.BARRIEREFREIHEIT_LINK_LABEL,
     url: "/barrierefreiheit",
-    h1: "Erklärung zur Barrierefreiheit",
+    h1: titles.BARRIEREFREIHEIT_TITLE,
   },
   {
-    label: "Hilfe und Kontakt",
+    label: contentLinkLabels.HILFE_UND_KONTAKT_LINK_LABEL,
     url: "/hilfe-und-kontakt",
-    h1: "Hilfe und Kontakt",
+    h1: titles.HILFE_UND_KONTAKT_TITLE,
   },
-  { label: "Open Source Code", url: "/open-source", h1: "Open Source Code" },
-  { label: "Impressum", url: "/impressum", h1: "Impressum" },
+  {
+    label: contentLinkLabels.OPEN_SOURCE_CODE_LINK_LABEL,
+    url: "/open-source",
+    h1: titles.OPEN_SOURCE_CODE_TITLE,
+  },
+  {
+    label: contentLinkLabels.IMPRESSUM_LINK_LABEL,
+    url: "/impressum",
+    h1: titles.IMPRESSUM_TITLE,
+  },
 ];
 
 test.describe("Footer (rendered for alle pages)", () => {

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -1,17 +1,15 @@
 import { expect, test } from "@playwright/test";
 import { LoginError } from "~/routes/action.login-user";
 import { LogoutType } from "~/routes/action.logout-user";
+import { getTestTranslations } from "~/util/testUtils";
 
 test.describe("Homepage (_index route)", () => {
+  const { titles, buttons, alerts, errorMessages } = getTestTranslations();
   test("has title, shows headline and introduction text", async ({ page }) => {
     await page.goto("/");
     await expect(page).toHaveTitle("Kommunikationsplattform | Justiz-Services");
     await expect(page.locator("text=Kommunikationsplattform")).toBeVisible();
-    await expect(
-      page.locator(
-        "text=Willkommen auf der Pilotplattform für den digitalen Austausch zwischen Gerichten und Verfahrensbeteiligten.",
-      ),
-    ).toBeVisible();
+    await expect(page.locator(`text=${titles.WELCOME_TITLE}`)).toBeVisible();
   });
 
   test('redirects to beA-Portal when using the "Anmeldung Anwaltschaft" login option', async ({
@@ -22,7 +20,7 @@ test.describe("Homepage (_index route)", () => {
     await page.goto("/");
     await page
       .getByRole("button", {
-        name: "Anmeldung Anwaltschaft",
+        name: buttons.LOGIN_BUTTON_BEA,
       })
       .click();
     await page.waitForURL((url) => url.toString().includes("schulung"));
@@ -40,7 +38,7 @@ test.describe("Homepage (_index route)", () => {
   }) => {
     await page.goto(`/login?status=${LogoutType.ByUser}`);
     await expect(page.getByRole("alert")).toContainText(
-      "Erfolgreich abgemeldet",
+      alerts.LOGOUT_BY_USER_MESSAGE,
     );
   });
 
@@ -49,7 +47,7 @@ test.describe("Homepage (_index route)", () => {
   }) => {
     await page.goto(`/login?status=${LogoutType.Automatic}`);
     await expect(page.getByRole("alert")).toContainText(
-      "Automatisch abgemeldet",
+      alerts.LOGOUT_AUTOMATIC_TITLE,
     );
   });
 
@@ -58,7 +56,7 @@ test.describe("Homepage (_index route)", () => {
   }) => {
     await page.goto(`/login?status=${LoginError.BeA}`);
     await expect(page.getByRole("alert")).toContainText(
-      "Fehler bei der Anmeldung",
+      errorMessages.LOGIN_ERROR_MESSAGE,
     );
   });
 });

--- a/tests/e2e/kopfzeile.spec.ts
+++ b/tests/e2e/kopfzeile.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
+import { getTestTranslations } from "~/util/testUtils";
 
 test.describe("Kopfzeile (rendered for all pages)", () => {
+  const { labels } = getTestTranslations();
   test("should render Kopfzeile on every page", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator(".kern-kopfzeile__flagge")).toBeVisible();
-    await expect(
-      page.getByText("Offizielle Website – Bundesrepublik Deutschland"),
-    ).toBeVisible();
+    await expect(page.getByText(labels.KOPFZEILE_LABEL)).toBeVisible();
   });
 });


### PR DESCRIPTION
Hi @joschka 
I would like to ask you to please review this PR as Manu is currently on holiday. Please take your time though 👌 

The code refactors all user-facing strings to use a centralised translations' context, replacing hardcoded German text. This prepares the app for internationalisation and simplifies maintenance. All main UI components, page metadata, and tests now use translation hooks and context.
Main changes:
- Replaced hardcoded labels, buttons, titles, and messages in major components with values from the translations' context via `useTranslations`.
- Wrapped the app in `TranslationsContext.Provider` (initialised with German).
- Context tests (`app/services/translations/__test__/context.test.tsx`) verify that text updates with language changes and that the default context state is correct.
- The `testUtils` module ensures both `renderWithTestTranslations` and `getTestTranslations` use the same dictionary, providing a single source of truth for translations in tests.
- Updated component tests to use the new test utilities and dynamic translation assertions.

These changes make it easy to support multiple languages and update translations going forward, in case we wanted to add this functionality in the future and load translations from the backend etc.

[JIRA ticket](https://digitalservicebund.atlassian.net/browse/KOMMPLA-490)